### PR TITLE
Fix crash during call to CommonMonitor.SetCharacterSlot

### DIFF
--- a/AquaMai/Fix/FixCharaCrash.cs
+++ b/AquaMai/Fix/FixCharaCrash.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using HarmonyLib;
 using Process;
 using Util;
@@ -5,24 +7,32 @@ using Util;
 namespace AquaMai.Fix
 {
     /**
-     * Fix character selection crashing because get map color returns null
+     * Fix character selection crashing due to missing character data
      */
-    public class FixCharaCrash
-    {
+    public class FixCharaCrash {
         // Check if the return is null. If it is, make up a color
         [HarmonyPostfix]
         [HarmonyPatch(typeof(CharacterSelectProces), "GetMapColorData")]
-        public static void GetMapColorData(ref CharacterSelectProces __instance, ref CharacterMapColorData __result)
-        {
-            if (__result != null) return;
-            
+        public static void GetMapColorData(ref CharacterSelectProces __instance, ref CharacterMapColorData __result) {
+            if (__result != null)
+                return;
+
             // 1 is a color that definitely exists
-            if (MapMaster.GetSlotData(1) == null)
-            {
+            if (MapMaster.GetSlotData(1) == null) {
                 MapMaster.GetSlotData(1).Load();
             }
             __result = MapMaster.GetSlotData(1);
         }
-        
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Monitor.CommonMonitor), "SetCharacterSlot", new Type[] { typeof(MessageCharactorInfomationData) })]
+        public static bool SetCharacterSlot(ref MessageCharactorInfomationData data, Dictionary<int, CharacterSlotData> ____characterSlotData) {
+            if (!____characterSlotData.ContainsKey(data.MapKey)) {
+                Console.Log($"Could not get CharacterSlotData for character [Index={data.Index}, MapKey={data.MapKey}], ignoring...");
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/AquaMai/Fix/FixCharaCrash.cs
+++ b/AquaMai/Fix/FixCharaCrash.cs
@@ -26,10 +26,12 @@ namespace AquaMai.Fix
             __result = MapMaster.GetSlotData(1);
         }
 
+        // This is called when loading the music selection screen, to display characters on the top screen
         [HarmonyPrefix]
         [HarmonyPatch(typeof(Monitor.CommonMonitor), "SetCharacterSlot", new Type[] { typeof(MessageCharactorInfomationData) })]
         public static bool SetCharacterSlot(ref MessageCharactorInfomationData data, Dictionary<int, CharacterSlotData> ____characterSlotData)
         {
+            // Some characters are not found in this dictionary. We simply skip loading those characters
             if (!____characterSlotData.ContainsKey(data.MapKey))
             {
                 Console.Log($"Could not get CharacterSlotData for character [Index={data.Index}, MapKey={data.MapKey}], ignoring...");

--- a/AquaMai/Fix/FixCharaCrash.cs
+++ b/AquaMai/Fix/FixCharaCrash.cs
@@ -9,16 +9,18 @@ namespace AquaMai.Fix
     /**
      * Fix character selection crashing due to missing character data
      */
-    public class FixCharaCrash {
+    public class FixCharaCrash
+    {
         // Check if the return is null. If it is, make up a color
         [HarmonyPostfix]
         [HarmonyPatch(typeof(CharacterSelectProces), "GetMapColorData")]
-        public static void GetMapColorData(ref CharacterSelectProces __instance, ref CharacterMapColorData __result) {
-            if (__result != null)
-                return;
+        public static void GetMapColorData(ref CharacterSelectProces __instance, ref CharacterMapColorData __result)
+        {
+            if (__result != null) return;
 
             // 1 is a color that definitely exists
-            if (MapMaster.GetSlotData(1) == null) {
+            if (MapMaster.GetSlotData(1) == null)
+            {
                 MapMaster.GetSlotData(1).Load();
             }
             __result = MapMaster.GetSlotData(1);
@@ -26,8 +28,10 @@ namespace AquaMai.Fix
 
         [HarmonyPrefix]
         [HarmonyPatch(typeof(Monitor.CommonMonitor), "SetCharacterSlot", new Type[] { typeof(MessageCharactorInfomationData) })]
-        public static bool SetCharacterSlot(ref MessageCharactorInfomationData data, Dictionary<int, CharacterSlotData> ____characterSlotData) {
-            if (!____characterSlotData.ContainsKey(data.MapKey)) {
+        public static bool SetCharacterSlot(ref MessageCharactorInfomationData data, Dictionary<int, CharacterSlotData> ____characterSlotData)
+        {
+            if (!____characterSlotData.ContainsKey(data.MapKey))
+            {
                 Console.Log($"Could not get CharacterSlotData for character [Index={data.Index}, MapKey={data.MapKey}], ignoring...");
                 return false;
             }


### PR DESCRIPTION
Fixes a crash when loading the music selection screen, where the call to retrieve character data to display on top monitor causes a KeyNotFound error. This fix simply doesn't load those characters.

上面小屏幕里的加载不出来的人物会变成空白。但是至少不会崩了……