### PR TITLE
Feature: Option to disable some useless checks and delays to speedup the game boot process

### DIFF
--- a/AquaMai/AquaMai.csproj
+++ b/AquaMai/AquaMai.csproj
@@ -266,6 +266,7 @@
     <Compile Include="Cheat\TicketUnlock.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="Fix\FixCharaCrash.cs" />
+    <Compile Include="Performance\ImproveLoadSpeed.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="UX\SinglePlayer.cs" />

--- a/AquaMai/AquaMai.toml
+++ b/AquaMai/AquaMai.toml
@@ -14,3 +14,7 @@ SkipWarningScreen=true
 SinglePlayer=true
 # !!EXPERIMENTAL!! Skip from the card-scanning screen directly to music selection screen
 SkipToMusicSelection=false
+
+[Performance]
+# Disable some useless checks and delays to speedup the game boot process
+ImproveLoadSpeed=false

--- a/AquaMai/Config.cs
+++ b/AquaMai/Config.cs
@@ -7,6 +7,7 @@ namespace AquaMai
     {
         public UXConfig UX { get; set; }
         public CheatConfig Cheat { get; set; }
+        public PerformanceConfig Performance { get; set; }
 
         public class CheatConfig
         {
@@ -18,6 +19,11 @@ namespace AquaMai
             public bool SkipWarningScreen { get; set; }
             public bool SinglePlayer { get; set; }
             public bool SkipToMusicSelection { get; set; }
+        }
+        
+        public class PerformanceConfig
+        {
+            public bool ImproveLoadSpeed { get; set; }
         }
     }
 }

--- a/AquaMai/Performance/ImproveLoadSpeed.cs
+++ b/AquaMai/Performance/ImproveLoadSpeed.cs
@@ -1,0 +1,57 @@
+﻿using System.Diagnostics;
+using HarmonyLib;
+using MelonLoader;
+using Process;
+
+namespace AquaMai.Performance
+{
+    public class ImproveLoadSpeed
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(PowerOnProcess), "OnUpdate")]
+        public static bool PrePowerOnUpdate(PowerOnProcess __instance)
+        {
+            var traverse = Traverse.Create(__instance);
+            var state = traverse.Field("_state").GetValue<byte>();
+            switch (state)
+            {
+                case 3:
+                    traverse.Field("_state").SetValue((byte)4);
+                    break;
+                case 5:
+                    traverse.Field("_state").SetValue((byte)8);
+                    break;
+                case 9:
+                    traverse.Field("_state").SetValue((byte)10);
+                    break;
+            }
+
+            return true;
+        }
+        
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(StartupProcess), "OnUpdate")]
+        public static bool PreStartupUpdate(StartupProcess __instance)
+        {
+            var traverse = Traverse.Create(__instance);
+            var state = traverse.Field("_state").GetValue<byte>();
+            switch (state)
+            {
+                case 0:
+                case 1:
+                case 2:
+                    traverse.Field("_state").SetValue((byte)3);
+                    break;
+                case 4:
+                    traverse.Field("_state").SetValue((byte)5);
+                    break;
+                case 8:
+                    var timer = traverse.Field("timer").GetValue<Stopwatch>();
+                    Traverse.Create(timer).Field("elapsed").SetValue(2 * 10000000L);
+                    break;
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
这个 PR 的内容应该需要经过一些测试，比如说它和 ADX 的兼容性之类的。它删除了启动流程中和数据加载无关的过程以及每个屏幕上的内容完成后的两秒钟延迟（有很多像这样的等待两秒的代码）。可以提升很多启动时间，不过会导致进游戏之后显示几秒的灰网，几秒后就正常了

![image](https://github.com/hykilpikonna/AquaDX/assets/18461360/b8710995-a506-4c97-8677-9068b87fecfd)
