### PR TITLE
The play count should be the PC count not the TRACK count.

### DIFF
--- a/AquaMai/UX/ImmediateSave.cs
+++ b/AquaMai/UX/ImmediateSave.cs
@@ -82,7 +82,6 @@ namespace AquaMai.UX
         {
             UserDetail detail = userData.Detail;
             _ = userData.ScoreList;
-            userData.AddPlayCount();
             detail.EventWatchedDate = TimeManager.GetDateString(TimeManager.PlayBaseTime);
             userData.CalcTotalValue();
             float num = 0f;


### PR DESCRIPTION
Fixed the bug where the play count would be +1 when TRACK ended an upload.

The original game used the number of PC as the player's game count.