### PR TITLE
Support More Custom Png Assets

### DIFF
--- a/AquaMai/UX/LoadAssetsPng.cs
+++ b/AquaMai/UX/LoadAssetsPng.cs
@@ -18,6 +18,14 @@ public class LoadAssetsPng
 {
     private static string[] imageExts = [".jpg", ".png", ".jpeg"];
     private static Dictionary<string, string> jacketPaths = new();
+    private static Dictionary<string, string> framePaths = new();
+    private static Dictionary<string, string> platePaths = new();
+    private static Dictionary<string, string> framemaskPaths = new();
+    private static Dictionary<string, string> framepatternPaths = new();
+    private static Dictionary<string, string> iconPaths = new();
+    private static Dictionary<string, string> charaPaths = new();
+    private static Dictionary<string, string> partnerPaths = new();
+    //private static Dictionary<string, string> navicharaPaths = new();
     private static Dictionary<string, string> tabTitlePaths = new();
     private static Dictionary<string, string> localAssetsContents = new();
 
@@ -35,6 +43,69 @@ public class LoadAssetsPng
                     jacketPaths[idStr] = file;
                 }
 
+            if (Directory.Exists(Path.Combine(aDir, @"AssetBundleImages\frame")))
+                foreach (var file in Directory.GetFiles(Path.Combine(aDir, @"AssetBundleImages\frame")))
+                {
+                    if (!imageExts.Contains(Path.GetExtension(file).ToLowerInvariant())) continue;
+                    var idStr = Path.GetFileName(file).Substring("ui_frame_".Length, 6);
+                    framePaths[idStr] = file;
+                }
+
+            if (Directory.Exists(Path.Combine(aDir, @"AssetBundleImages\nameplate")))
+                foreach (var file in Directory.GetFiles(Path.Combine(aDir, @"AssetBundleImages\nameplate")))
+                {
+                    if (!imageExts.Contains(Path.GetExtension(file).ToLowerInvariant())) continue;
+                    var idStr = Path.GetFileName(file).Substring("ui_plate_".Length, 6);
+                    platePaths[idStr] = file;
+                }
+
+            if (Directory.Exists(Path.Combine(aDir, @"AssetBundleImages\framemask")))
+                foreach (var file in Directory.GetFiles(Path.Combine(aDir, @"AssetBundleImages\framemask")))
+                {
+                    if (!imageExts.Contains(Path.GetExtension(file).ToLowerInvariant())) continue;
+                    var idStr = Path.GetFileName(file).Substring("ui_framemask_".Length, 6);
+                    framemaskPaths[idStr] = file;
+                }
+
+            if (Directory.Exists(Path.Combine(aDir, @"AssetBundleImages\framepattern")))
+                foreach (var file in Directory.GetFiles(Path.Combine(aDir, @"AssetBundleImages\framepattern")))
+                {
+                    if (!imageExts.Contains(Path.GetExtension(file).ToLowerInvariant())) continue;
+                    var idStr = Path.GetFileName(file).Substring("ui_framepattern_".Length, 6);
+                    framepatternPaths[idStr] = file;
+                }
+
+            if (Directory.Exists(Path.Combine(aDir, @"AssetBundleImages\icon")))
+                foreach (var file in Directory.GetFiles(Path.Combine(aDir, @"AssetBundleImages\icon")))
+                {
+                    if (!imageExts.Contains(Path.GetExtension(file).ToLowerInvariant())) continue;
+                    var idStr = Path.GetFileName(file).Substring("ui_icon_".Length, 6);
+                    iconPaths[idStr] = file;
+                }
+
+            if (Directory.Exists(Path.Combine(aDir, @"AssetBundleImages\chara")))
+                foreach (var file in Directory.GetFiles(Path.Combine(aDir, @"AssetBundleImages\chara")))
+                {
+                    if (!imageExts.Contains(Path.GetExtension(file).ToLowerInvariant())) continue;
+                    var idStr = Path.GetFileName(file).Substring("ui_chara_".Length, 6);
+                    charaPaths[idStr] = file;
+                }
+
+            if (Directory.Exists(Path.Combine(aDir, @"AssetBundleImages\partner")))
+                foreach (var file in Directory.GetFiles(Path.Combine(aDir, @"AssetBundleImages\partner")))
+                {
+                    if (!imageExts.Contains(Path.GetExtension(file).ToLowerInvariant())) continue;
+                    var idStr = Path.GetFileName(file).Substring("ui_Partner_".Length, 6);
+                    partnerPaths[idStr] = file;
+                }
+            //if (Directory.Exists(Path.Combine(aDir, @"AssetBundleImages\navichara\sprite\parts\ui_navichara_21")))
+            //  foreach (var file in Directory.GetFiles(Path.Combine(aDir, @"AssetBundleImages\navichara\sprite\parts\ui_navichara_", charaid)))
+            //{
+            //  if (!imageExts.Contains(Path.GetExtension(file).ToLowerInvariant())) continue;
+            //var idStr = Path.GetFileName(file).Substring("ui_navichara_".Length, 6);
+            //        navicharaPaths[idStr] = file;
+            //  }
+
             if (Directory.Exists(Path.Combine(aDir, @"Common\Sprites\Tab\Title")))
                 foreach (var file in Directory.GetFiles(Path.Combine(aDir, @"Common\Sprites\Tab\Title")))
                 {
@@ -43,7 +114,7 @@ public class LoadAssetsPng
                 }
         }
 
-        MelonLogger.Msg($"[LoadAssetsPng] Loaded {jacketPaths.Count} Jacket, {tabTitlePaths.Count} Tab Titles from AssetBundleImages.");
+        MelonLogger.Msg($"[LoadAssetsPng] Loaded {jacketPaths.Count} Jacket, {platePaths.Count} NamePlate, {framePaths.Count} Frame, {framemaskPaths.Count} FrameMask, {framepatternPaths.Count} FramePattern, {iconPaths.Count} Icon, {charaPaths.Count} Chara, {partnerPaths.Count} PartnerLogo, {tabTitlePaths.Count} Tab Titles from AssetBundleImages.");
 
         if (Directory.Exists(Path.Combine(Environment.CurrentDirectory, "LocalAssets")))
             foreach (var laFile in Directory.EnumerateFiles(Path.Combine(Environment.CurrentDirectory, "LocalAssets")))
@@ -76,6 +147,128 @@ public class LoadAssetsPng
     public static Texture2D GetJacketTexture2D(int id)
     {
         return GetJacketTexture2D($"{id:000000}");
+    }
+
+    private static string GetFramePath(string id)
+    {
+        return framePaths.GetValueOrDefault(id);
+    }
+
+    public static Texture2D GetFrameTexture2D(string id)
+    {
+        var path = GetFramePath(id);
+        if (path == null)
+        {
+            return null;
+        }
+
+        var texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+        texture.LoadImage(File.ReadAllBytes(path));
+        return texture;
+    }
+    private static string GetPlatePath(string id)
+    {
+        return platePaths.GetValueOrDefault(id);
+    }
+
+    public static Texture2D GetPlateTexture2D(string id)
+    {
+        var path = GetPlatePath(id);
+        if (path == null)
+        {
+            return null;
+        }
+
+        var texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+        texture.LoadImage(File.ReadAllBytes(path));
+        return texture;
+    }
+
+    private static string GetFrameMaskPath(string id)
+    {
+        return framemaskPaths.GetValueOrDefault(id);
+    }
+
+    public static Texture2D GetFrameMaskTexture2D(string id)
+    {
+        var path = GetFrameMaskPath(id);
+        if (path == null)
+        {
+            return null;
+        }
+
+        var texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+        texture.LoadImage(File.ReadAllBytes(path));
+        return texture;
+    }
+
+    private static string GetFramePatternPath(string id)
+    {
+        return framepatternPaths.GetValueOrDefault(id);
+    }
+
+    public static Texture2D GetFramePatternTexture2D(string id)
+    {
+        var path = GetFramePatternPath(id);
+        if (path == null)
+        {
+            return null;
+        }
+
+        var texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+        texture.LoadImage(File.ReadAllBytes(path));
+        return texture;
+    }
+    private static string GetIconPath(string id)
+    {
+        return iconPaths.GetValueOrDefault(id);
+    }
+
+    public static Texture2D GetIconTexture2D(string id)
+    {
+        var path = GetIconPath(id);
+        if (path == null)
+        {
+            return null;
+        }
+
+        var texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+        texture.LoadImage(File.ReadAllBytes(path));
+        return texture;
+    }
+    private static string GetCharaPath(string id)
+    {
+        return charaPaths.GetValueOrDefault(id);
+    }
+
+    public static Texture2D GetCharaTexture2D(string id)
+    {
+        var path = GetCharaPath(id);
+        if (path == null)
+        {
+            return null;
+        }
+
+        var texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+        texture.LoadImage(File.ReadAllBytes(path));
+        return texture;
+    }
+    private static string GetPartnerPath(string id)
+    {
+        return partnerPaths.GetValueOrDefault(id);
+    }
+
+    public static Texture2D GetPartnerTexture2D(string id)
+    {
+        var path = GetPartnerPath(id);
+        if (path == null)
+        {
+            return null;
+        }
+
+        var texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+        texture.LoadImage(File.ReadAllBytes(path));
+        return texture;
     }
 
     /*
@@ -168,4 +361,217 @@ public class LoadAssetsPng
             return false;
         }
     }
+
+    [HarmonyPatch]
+    public static class FrameLoader
+    {
+        public static IEnumerable<MethodBase> TargetMethods()
+        {
+            var AM = typeof(AssetManager);
+            return [AM.GetMethod("GetFrameThumbTexture2D", [typeof(string)]), AM.GetMethod("GetFrameTexture2D", [typeof(string)])];
+        }
+
+        public static bool Prefix(string filename, ref Texture2D __result, AssetManager __instance)
+        {
+            var matches = Regex.Matches(filename, @"UI_Frame_(\d+)(_s)?\.png");
+            if (matches.Count < 1)
+            {
+                return true;
+            }
+
+            var id = matches[0].Groups[1].Value;
+
+            var texture = GetFrameTexture2D(id);
+            __result = texture ?? __instance.LoadAsset<Texture2D>($"Frame/UI_Frame_{id}.png");
+
+            return false;
+        }
+    }
+
+    [HarmonyPatch]
+    public static class PlateLoader
+    {
+        public static IEnumerable<MethodBase> TargetMethods()
+        {
+            var AM = typeof(AssetManager);
+            return [AM.GetMethod("GetPlateTexture2D", [typeof(string)])];
+        }
+
+        public static bool Prefix(string filename, ref Texture2D __result, AssetManager __instance)
+        {
+            var matches = Regex.Matches(filename, @"UI_Plate_(\d+)\.png");
+            if (matches.Count < 1)
+            {
+                return true;
+            }
+
+            var id = matches[0].Groups[1].Value;
+
+            var texture = GetPlateTexture2D(id);
+            __result = texture ?? __instance.LoadAsset<Texture2D>($"NamePlate/UI_Plate_{id}.png");
+
+            return false;
+        }
+    }
+
+    [HarmonyPatch]
+    public static class FrameMaskLoader
+    {
+        public static IEnumerable<MethodBase> TargetMethods()
+        {
+            var AM = typeof(AssetManager);
+            return [AM.GetMethod("GetFrameMaskTexture2D", [typeof(string)])];
+        }
+
+        public static bool Prefix(string filename, ref Texture2D __result, AssetManager __instance)
+        {
+            var matches = Regex.Matches(filename, @"UI_FrameMask_(\d+)\.png");
+            if (matches.Count < 1)
+            {
+                return true;
+            }
+
+            var id = matches[0].Groups[1].Value;
+
+            var texture = GetFrameMaskTexture2D(id);
+            __result = texture ?? __instance.LoadAsset<Texture2D>($"FrameMask/UI_FrameMask_{id}.png");
+
+            return false;
+        }
+    }
+
+    [HarmonyPatch]
+    public static class FramePatternLoader
+    {
+        public static IEnumerable<MethodBase> TargetMethods()
+        {
+            var AM = typeof(AssetManager);
+            return [AM.GetMethod("GetFramePatternTexture2D", [typeof(string)])];
+        }
+
+        public static bool Prefix(string filename, ref Texture2D __result, AssetManager __instance)
+        {
+            var matches = Regex.Matches(filename, @"UI_FramePattern_(\d+)\.png");
+            if (matches.Count < 1)
+            {
+                return true;
+            }
+
+            var id = matches[0].Groups[1].Value;
+
+            var texture = GetFramePatternTexture2D(id);
+            __result = texture ?? __instance.LoadAsset<Texture2D>($"FramePattern/UI_FramePattern_{id}.png");
+
+            return false;
+        }
+    }
+
+    [HarmonyPatch]
+    public static class IconLoader
+    {
+        public static IEnumerable<MethodBase> TargetMethods()
+        {
+            var AM = typeof(AssetManager);
+            var method = AM.GetMethod("GetIconTexture2D", new[] { typeof(string) });
+            if (method != null)
+            {
+                yield return method;
+            }
+        }
+
+        public static bool Prefix(string filename, ref Texture2D __result, AssetManager __instance)
+        {
+            var matches = Regex.Matches(filename, @"UI_Icon_(\d+)\.png");
+            if (matches.Count < 1)
+            {
+                return true;
+            }
+            MelonLogger.Msg(filename);
+            var id = matches[0].Groups[1].Value;
+
+            var texture = GetIconTexture2D(id);
+            __result = texture ?? __instance.LoadAsset<Texture2D>($"Icon/UI_Icon_{id}.png");
+
+            return false;
+        }
+    }
+
+    [HarmonyPatch]
+    public static class CharaLoader
+    {
+        public static IEnumerable<MethodBase> TargetMethods()
+        {
+            var AM = typeof(AssetManager);
+            return [AM.GetMethod("GetCharacterTexture2D", [typeof(string)])];
+        }
+
+        public static bool Prefix(string filename, ref Texture2D __result, AssetManager __instance)
+        {
+            var matches = Regex.Matches(filename, @"UI_Chara_(\d+)\.png");
+            if (matches.Count < 1)
+            {
+                return true;
+            }
+
+            var id = matches[0].Groups[1].Value;
+
+            var texture = GetCharaTexture2D(id);
+            __result = texture ?? __instance.LoadAsset<Texture2D>($"Chara/UI_Chara_{id}.png");
+
+            return false;
+        }
+    }
+  
+    [HarmonyPatch]
+    public static class PartnerLoader
+    {
+        public static IEnumerable<MethodBase> TargetMethods()
+        {
+            var AM = typeof(AssetManager);
+            return [AM.GetMethod("GetPartnerTexture2D", [typeof(string)])];
+        }
+
+        public static bool Prefix(string filename, ref Texture2D __result, AssetManager __instance)
+        {
+            var matches = Regex.Matches(filename, @"UI_Partner_(\d+)\.png");
+            if (matches.Count < 1)
+            {
+                return true;
+            }
+
+            var id = matches[0].Groups[1].Value;
+
+            var texture = GetPartnerTexture2D(id);
+            __result = texture ?? __instance.LoadAsset<Texture2D>($"Partner/UI_Partner_{id}.png");
+
+            return false;
+        }
+    }
+    /*
+    [HarmonyPatch]
+    public static class FrameLoader
+    {
+        public static IEnumerable<MethodBase> TargetMethods()
+        {
+            var AM = typeof(AssetManager);
+            return [AM.GetMethod("GetFrameThumbTexture2D", [typeof(string)]), AM.GetMethod("GetFrameTexture2D", [typeof(string)])];
+        }
+
+        public static bool Prefix(string filename, ref Texture2D __result, AssetManager __instance)
+        {
+            var matches = Regex.Matches(filename, @"UI_Frame_(\d+)\.png");
+            if (matches.Count < 1)
+            {
+                return true;
+            }
+
+            var id = matches[0].Groups[1].Value;
+
+            var texture = GetFrameTexture2D(id);
+            __result = texture ?? __instance.LoadAsset<Texture2D>($"Frame/UI_Frame_{id}.png");
+
+            return false;
+        }
+    }
+    */
 }


### PR DESCRIPTION
素材放置于AssetBundleImages，支持姓名框背景板旅行伙伴，Icon会报错，不影响游玩，在修，navichara和PartnerResult在写，原有的TabTitle在kop预选会有显示问题，还没找到修的方法。其实都是复制粘贴，至于新收藏品的配置文件，目前还没写完批量生成的，可能会参考旧框的管理器