### PR TITLE
AquaMai fix for crashes caused by empty date parsing

### DIFF
--- a/AquaMai/Fix/FixEmptyDateCrash.cs
+++ b/AquaMai/Fix/FixEmptyDateCrash.cs
@@ -23,7 +23,7 @@ namespace AquaMai.Fix
             if (string.IsNullOrWhiteSpace(s))
             {
                 __result = DateTime.MinValue; // DateTime.Now will crash the game
-                MelonLogger.Msg($"[FixDateParsingCrash] Empty date string, defaulting to {__result.ToString("yyyy/MM/dd HH:mm:ss", JapaneseCulture)}");
+                MelonLogger.Msg($"[FixEmptyDateCrash] Empty date string, defaulting to {__result.ToString("yyyy/MM/dd HH:mm:ss", JapaneseCulture)}");
                 return false;
             }
 

--- a/AquaMai/Fix/FixEmptyDateCrash.cs
+++ b/AquaMai/Fix/FixEmptyDateCrash.cs
@@ -14,7 +14,7 @@ namespace AquaMai.Fix
         private static readonly CultureInfo JapaneseCulture = new CultureInfo("ja-JP");
 
         /**
-         * Switch the return value to DateTime.MinValue if the input string is empty or null.
+         * Replace the return value to DateTime.MinValue if the input string is empty or null.
          */
         [HarmonyPrefix]
         [HarmonyPatch(typeof(DateTime), "Parse", new Type[] { typeof(string) })]

--- a/AquaMai/Fix/FixEmptyDateCrash.cs
+++ b/AquaMai/Fix/FixEmptyDateCrash.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using HarmonyLib;
 using MelonLoader;
+using Manager;
 
 namespace AquaMai.Fix
 {
@@ -22,7 +23,7 @@ namespace AquaMai.Fix
         {
             if (string.IsNullOrWhiteSpace(s))
             {
-                __result = DateTime.MinValue; // DateTime.Now will crash the game
+                __result = TimeManager.GetNowTime();
                 MelonLogger.Msg($"[FixEmptyDateCrash] Empty date string, defaulting to {__result.ToString("yyyy/MM/dd HH:mm:ss", JapaneseCulture)}");
                 return false;
             }

--- a/AquaMai/Fix/FixEmptyDateCrash.cs
+++ b/AquaMai/Fix/FixEmptyDateCrash.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Globalization;
+using HarmonyLib;
+using MelonLoader;
+
+namespace AquaMai.Fix
+{
+    /*
+     * Fix a specific crash caused by the system using an incompatible date format.
+     * This leads to the game trying to parse an empty date.
+     */
+    public class FixEmptyDateCrash
+    {
+        private static readonly CultureInfo JapaneseCulture = new CultureInfo("ja-JP");
+
+        /**
+         * Switch the return value to DateTime.MinValue if the input string is empty or null.
+         */
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DateTime), "Parse", new Type[] { typeof(string) })]
+        public static bool FixEmptyDate(ref DateTime __result, string s)
+        {
+            if (string.IsNullOrWhiteSpace(s))
+            {
+                __result = DateTime.MinValue; // DateTime.Now will crash the game
+                MelonLogger.Msg($"[FixDateParsingCrash] Empty date string, defaulting to {__result.ToString("yyyy/MM/dd HH:mm:ss", JapaneseCulture)}");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/AquaMai/Fix/FixEmptyDateCrash.cs
+++ b/AquaMai/Fix/FixEmptyDateCrash.cs
@@ -17,7 +17,7 @@ namespace AquaMai.Fix
          * Replace the return value to DateTime.MinValue if the input string is empty or null.
          */
         [HarmonyPrefix]
-        [HarmonyPatch(typeof(DateTime), "Parse", new Type[] { typeof(string) })]
+        [HarmonyPatch(typeof(DateTime), "Parse", typeof(string))]
         public static bool FixEmptyDate(ref DateTime __result, string s)
         {
             if (string.IsNullOrWhiteSpace(s))

--- a/AquaMai/Main.cs
+++ b/AquaMai/Main.cs
@@ -169,6 +169,7 @@ namespace AquaMai
             Patch(typeof(DebugFeature));
             Patch(typeof(FixConnSlide));
             Patch(typeof(FestivalQuickRetryFix));
+            Patch(typeof(FixEmptyDateCrash));
             // Visual
             Patch(typeof(FixSlideAutoPlay)); // Rename: SlideAutoPlayTweak -> FixSlideAutoPlay, 不过这个应该无副作用所以不需要改配置文件
             Patch(typeof(FixCircleSlideJudge)); // 这个我觉得算无副作用, 可以常开


### PR DESCRIPTION
Fixes #87 

Checks for empty or null strings trying to be parsed and returns `DateTime.MinValue` instead  of parsing.
Tried using `DateTime.Now` instead but the game still crashed.