### PR TITLE
[F] Set ForceAsSserver to default ON

### DIFF
--- a/AquaMai/AquaMai.Config/Migration/ConfigMigration_V1_0_V2_0.cs
+++ b/AquaMai/AquaMai.Config/Migration/ConfigMigration_V1_0_V2_0.cs
@@ -125,7 +125,10 @@ public class ConfigMigration_V1_0_V2_0 : IConfigMigration
         {
             dst.SetValue("GameSystem.RemoveEncryption.Disabled", true); // Enabled by default in V2
         }
-        MapBooleanTrueToSectionEnable(src, dst, "Fix.ForceAsServer", "GameSettings.ForceAsServer");
+        if (!src.GetValueOrDefault<bool>("Fix.ForceAsServer"))
+        {
+            dst.SetValue("GameSettings.ForceAsServer.Disabled", true); // Enabled by default in V2
+        }
         if (src.GetValueOrDefault<bool>("Fix.ForceFreePlay"))
         {
             dst.SetValue("GameSettings.CreditConfig.IsFreePlay", true);
@@ -297,6 +300,7 @@ public class ConfigMigration_V1_0_V2_0 : IConfigMigration
 
         // Default enabled in V2
         dst.EnsureDictionary("GameSystem.RemoveEncryption");
+        dst.EnsureDictionary("GameSettings.ForceAsServer");
 
         return dst;
     }

--- a/AquaMai/AquaMai.Config/Migration/ConfigMigration_V1_0_V2_0.cs
+++ b/AquaMai/AquaMai.Config/Migration/ConfigMigration_V1_0_V2_0.cs
@@ -125,7 +125,7 @@ public class ConfigMigration_V1_0_V2_0 : IConfigMigration
         {
             dst.SetValue("GameSystem.RemoveEncryption.Disabled", true); // Enabled by default in V2
         }
-        if (!src.GetValueOrDefault<bool>("Fix.ForceAsServer"))
+        if (!src.GetValueOrDefault<bool>("Fix.ForceAsServer", true))
         {
             dst.SetValue("GameSettings.ForceAsServer.Disabled", true); // Enabled by default in V2
         }

--- a/AquaMai/AquaMai.Mods/GameSettings/ForceAsServer.cs
+++ b/AquaMai/AquaMai.Mods/GameSettings/ForceAsServer.cs
@@ -6,7 +6,8 @@ namespace AquaMai.Mods.GameSettings;
 
 [ConfigSection(
     en: "If you want to configure in-shop party-link, you should turn this off.",
-    zh: "如果要配置店内招募的话，应该要把这个关闭")]
+    zh: "如果要配置店内招募的话，应该要把这个关闭",
+    defaultOn: true)]
 public class ForceAsServer
 {
     [HarmonyPrefix]


### PR DESCRIPTION
## Summary by Sourcery

在版本2中，将“ForceAsServer”配置设置为默认启用，并确保在迁移过程中创建相应的字典。

新功能：
- 在版本2中，将“ForceAsServer”配置设置为默认启用。

增强功能：
- 确保在迁移过程中创建“GameSettings.ForceAsServer”字典。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Set the 'ForceAsServer' configuration to be enabled by default in version 2 and ensure the corresponding dictionary is created during migration.

New Features:
- Set 'ForceAsServer' configuration to be enabled by default in version 2.

Enhancements:
- Ensure the 'GameSettings.ForceAsServer' dictionary is created during migration.

</details>