### PR TITLE
[F] AimeDB Felica Lookup v2 rename package parameter

### DIFF
--- a/src/main/java/icu/samnyan/aqua/sega/aimedb/AimeDB.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/aimedb/AimeDB.kt
@@ -114,7 +114,7 @@ class AimeDB(
      */
     fun doFelicaLookupV2(msg: ByteBuf): ByteBuf {
         val idm = msg.slice(0x30, 0x38 - 0x30).getLong(0)
-        val pmm = msg.slice(0x38, 0x40 - 0x38).getLong(0)
+        val dfc = msg.slice(0x38, 0x40 - 0x38).getLong(0)
         logger.info("> Felica Lookup v2 (idm $idm, pmm $pmm)")
 
         // Get the decimal represent of the hex value, same from minime

--- a/src/main/java/icu/samnyan/aqua/sega/aimedb/AimeDB.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/aimedb/AimeDB.kt
@@ -115,7 +115,7 @@ class AimeDB(
     fun doFelicaLookupV2(msg: ByteBuf): ByteBuf {
         val idm = msg.slice(0x30, 0x38 - 0x30).getLong(0)
         val dfc = msg.slice(0x38, 0x40 - 0x38).getLong(0)
-        logger.info("> Felica Lookup v2 (idm $idm, pmm $pmm)")
+        logger.info("> Felica Lookup v2 (idm $idm, dfc $dfc)")
 
         // Get the decimal represent of the hex value, same from minime
         val accessCode = idm.toString().replace("-", "").padStart(20, '0')


### PR DESCRIPTION
Get Account Information with Extended Security( 0x11 , FelicaLookupV2 )

跟随在idm后面的8个字节并不是pmm，
而是Felica Lite-S的0x8082(ID)块的后八个字节（DFC）：
<img width="371" alt="image" src="https://github.com/user-attachments/assets/401504cb-4ca9-4992-ba00-347bdc246dac">
例如sega的aic读取0x8082(ID)块到的是：[8 bytes idm] 00 78 00 00 00 00 00 00
并不是从0x8083(D_ID)块中读取的idm和pmm：[8 bytes idm] 00 F1 00 00 00 01 43 00

因为各种原因该命令其中本应是dfc的参数被错误的当作了pmm，并流传至今，这个误解会影响到尝试实现官方aimedb查询卡号的人

## Summary by Sourcery

错误修复：
- 在 Felica Lookup v2 函数中将参数名称从 'pmm' 更正为 'dfc' 以反映实际处理的数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the parameter name from 'pmm' to 'dfc' in the Felica Lookup v2 function to reflect the actual data being processed.

</details>