### PR TITLE
[RF] move userMusicFromList to GameApiController and add GenericUserM…

### DIFF
--- a/src/main/java/icu/samnyan/aqua/net/games/GameApiController.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/GameApiController.kt
@@ -22,6 +22,7 @@ abstract class GameApiController<T : IUserData>(val name: String, userDataClass:
     abstract val us: AquaUserServices
     abstract val userDataRepo: GenericUserDataRepo<T>
     abstract val playlogRepo: GenericPlaylogRepo<*>
+    abstract val userMusicRepo: GenericUserMusicRepo<*>
     abstract val shownRanks: List<Pair<Int, String>>
     abstract val settableFields: Map<String, (T, String) -> Unit>
     open val gettableFields: Set<String> = setOf()
@@ -131,6 +132,11 @@ abstract class GameApiController<T : IUserData>(val name: String, userDataClass:
             async { userDataRepo.save(user) }
             SUCCESS
         }
+    }
+
+    @API("user-music-from-list")
+    suspend fun userMusicFromList(@RP username: Str, @RB musicList: List<Int>) = us.cardByName(username) { card ->
+        userMusicRepo.findByUser_Card_ExtIdAndMusicIdIn(card.extId, musicList)
     }
 
     fun genericUserSummary(card: Card, ratingComp: Map<String, String>, rival: Boolean? = null): GenericGameSummary {

--- a/src/main/java/icu/samnyan/aqua/net/games/Models.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/Models.kt
@@ -107,6 +107,10 @@ interface IGenericGamePlaylog {
     val isAllPerfect: Boolean
 }
 
+interface IGenericUserMusic {
+    val musicId: Int
+}
+
 @MappedSuperclass
 open class BaseEntity(
     @Id
@@ -130,6 +134,12 @@ interface GenericUserDataRepo<T : IUserData> : JpaRepository<T, Long> {
 interface GenericPlaylogRepo<T: IGenericGamePlaylog> : JpaRepository<T, Long> {
     fun findByUserCardExtId(extId: Long): List<T>
     fun findByUserCardExtId(extId: Long, page: Pageable): Page<T>
+}
+
+@NoRepositoryBean
+interface GenericUserMusicRepo<T: IGenericUserMusic> : JpaRepository<T, Long> {
+    fun findByUserCardExtId(extId: Long): List<T>
+    fun findByUser_Card_ExtIdAndMusicIdIn(userId: Long, musicId: List<Int>): List<T>
 }
 
 data class ImportResult(val errors: List<String>, val warnings: List<String>, val json: String)

--- a/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
@@ -14,6 +14,7 @@ class Chusan(
     override val us: AquaUserServices,
     override val playlogRepo: Chu3UserPlaylogRepo,
     override val userDataRepo: Chu3UserDataRepo,
+    override val userMusicRepo: Chu3UserMusicDetailRepo,
     val rp: Chu3Repos
 ): GameApiController<Chu3UserData>("chu3", Chu3UserData::class) {
     override suspend fun trend(@RP username: Str): List<TrendOut> = us.cardByName(username) { card ->

--- a/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
@@ -16,6 +16,7 @@ class Maimai2(
     override val us: AquaUserServices,
     override val playlogRepo: Mai2UserPlaylogRepo,
     override val userDataRepo: Mai2UserDataRepo,
+    override val userMusicRepo: Mai2UserMusicDetailRepo,
     val repos: Mai2Repos,
 ) : GameApiController<Mai2UserDetail>("mai2", Mai2UserDetail::class) {
     override suspend fun trend(@RP username: Str): List<TrendOut> = us.cardByName(username) { card ->
@@ -97,11 +98,6 @@ class Maimai2(
     @API("user-favorite")
     suspend fun userFavorite(@RP username: Str) = us.cardByName(username) { card ->
         repos.userFavorite.findByUser_Card_ExtId(card.extId)
-    }
-
-    @API("user-music-from-list")
-    suspend fun userMusicFromList(@RP username: Str, @RB musicList: List<Int>) = us.cardByName(username) { card ->
-        repos.userMusicDetail.findByUser_Card_ExtIdAndMusicIdIn(card.extId, musicList)
     }
 
     @PostMapping("change-name")

--- a/src/main/java/icu/samnyan/aqua/net/games/ongeki/Ongeki.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/ongeki/Ongeki.kt
@@ -6,6 +6,7 @@ import icu.samnyan.aqua.net.games.*
 import icu.samnyan.aqua.net.utils.*
 import icu.samnyan.aqua.sega.ongeki.dao.userdata.UserDataRepository
 import icu.samnyan.aqua.sega.ongeki.dao.userdata.UserGeneralDataRepository
+import icu.samnyan.aqua.sega.ongeki.dao.userdata.UserMusicDetailRepository
 import icu.samnyan.aqua.sega.ongeki.dao.userdata.UserPlaylogRepository
 import icu.samnyan.aqua.sega.ongeki.model.userdata.UserData
 import org.springframework.web.bind.annotation.RestController
@@ -16,6 +17,7 @@ class Ongeki(
     override val us: AquaUserServices,
     override val playlogRepo: UserPlaylogRepository,
     override val userDataRepo: UserDataRepository,
+    override val userMusicRepo: UserMusicDetailRepository,
     val userGeneralDataRepository: UserGeneralDataRepository
 ): GameApiController<UserData>("ongeki", UserData::class) {
     override suspend fun trend(username: String) = us.cardByName(username) { card ->

--- a/src/main/java/icu/samnyan/aqua/net/games/wacca/Wacca.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/wacca/Wacca.kt
@@ -5,6 +5,7 @@ import icu.samnyan.aqua.net.db.AquaUserServices
 import icu.samnyan.aqua.net.games.*
 import icu.samnyan.aqua.net.utils.waccaScores
 import icu.samnyan.aqua.sega.wacca.model.db.WaccaUser
+import icu.samnyan.aqua.sega.wacca.model.db.WcUserBestScoreRepo
 import icu.samnyan.aqua.sega.wacca.model.db.WcUserPlayLogRepo
 import icu.samnyan.aqua.sega.wacca.model.db.WcUserRepo
 import org.springframework.web.bind.annotation.RestController
@@ -15,6 +16,7 @@ class Wacca(
     override val us: AquaUserServices,
     override val playlogRepo: WcUserPlayLogRepo,
     override val userDataRepo: WcUserRepo,
+    override val userMusicRepo: WcUserBestScoreRepo,
 ): GameApiController<WaccaUser>("wacca", WaccaUser::class) {
     override val settableFields: Map<String, (WaccaUser, String) -> Unit> by lazy { mapOf(
         "userName" to usernameCheck(WACCA_USERNAME_CHARS),

--- a/src/main/java/icu/samnyan/aqua/sega/chusan/model/Chu3Repos.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/chusan/model/Chu3Repos.kt
@@ -4,8 +4,10 @@ package icu.samnyan.aqua.sega.chusan.model
 
 import icu.samnyan.aqua.net.games.GenericPlaylogRepo
 import icu.samnyan.aqua.net.games.GenericUserDataRepo
+import icu.samnyan.aqua.net.games.GenericUserMusicRepo
 import icu.samnyan.aqua.net.games.IUserRepo
 import icu.samnyan.aqua.sega.chusan.model.userdata.*
+import icu.samnyan.aqua.sega.maimai2.model.userdata.Mai2UserMusicDetail
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
@@ -104,7 +106,7 @@ interface Chu3UserMapRepo : Chu3UserLinked<UserMap> {
     fun findAllByUserCardExtIdAndMapAreaIdIn(user: Long, mapAreaIds: List<Int>): List<UserMap>
 }
 
-interface Chu3UserMusicDetailRepo : Chu3UserLinked<UserMusicDetail> {
+interface Chu3UserMusicDetailRepo : Chu3UserLinked<UserMusicDetail>, GenericUserMusicRepo<UserMusicDetail> {
     fun findTopByUserAndMusicIdAndLevelOrderByIdDesc(user: Chu3UserData, musicId: Int, level: Int): Optional<UserMusicDetail>
     fun findByUserAndMusicIdAndLevel(user: Chu3UserData, musicId: Int, level: Int): UserMusicDetail?
 

--- a/src/main/java/icu/samnyan/aqua/sega/chusan/model/userdata/UserMusicDetail.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/chusan/model/userdata/UserMusicDetail.kt
@@ -2,6 +2,7 @@ package icu.samnyan.aqua.sega.chusan.model.userdata
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import icu.samnyan.aqua.net.games.IGenericUserMusic
 import icu.samnyan.aqua.sega.util.jackson.BooleanToIntegerDeserializer
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
@@ -15,8 +16,8 @@ import jakarta.persistence.UniqueConstraint
     name = "chusan_user_music_detail",
     uniqueConstraints = [UniqueConstraint(columnNames = ["user_id", "music_id", "level"])]
 )
-class UserMusicDetail : Chu3UserEntity() {
-    var musicId = 0
+class UserMusicDetail : Chu3UserEntity(), IGenericUserMusic {
+    override var musicId = 0
     var level = 0
     var playCount = 0
     var scoreMax = 0

--- a/src/main/java/icu/samnyan/aqua/sega/maimai2/model/Repos.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/maimai2/model/Repos.kt
@@ -4,6 +4,7 @@ package icu.samnyan.aqua.sega.maimai2.model
 
 import icu.samnyan.aqua.net.games.GenericPlaylogRepo
 import icu.samnyan.aqua.net.games.GenericUserDataRepo
+import icu.samnyan.aqua.net.games.GenericUserMusicRepo
 import icu.samnyan.aqua.net.games.IUserRepo
 import icu.samnyan.aqua.sega.general.model.Card
 import icu.samnyan.aqua.sega.maimai2.model.userdata.*
@@ -90,12 +91,10 @@ interface Mai2UserMapRepo : Mai2UserLinked<Mai2UserMap> {
     fun findByUserAndMapId(user: Mai2UserDetail, mapId: Int): Optional<Mai2UserMap>
 }
 
-interface Mai2UserMusicDetailRepo : Mai2UserLinked<Mai2UserMusicDetail> {
+interface Mai2UserMusicDetailRepo : Mai2UserLinked<Mai2UserMusicDetail>, GenericUserMusicRepo<Mai2UserMusicDetail> {
     fun findByUser_Card_ExtIdAndMusicId(userId: Long, id: Int): List<Mai2UserMusicDetail>
 
     fun findByUserAndMusicIdAndLevel(user: Mai2UserDetail, musicId: Int, level: Int): Optional<Mai2UserMusicDetail>
-
-    fun findByUser_Card_ExtIdAndMusicIdIn(userId: Long, musicId: List<Int>): List<Mai2UserMusicDetail>
 
     fun findByUserId(userId: Long): List<Mai2UserMusicDetail>
 }

--- a/src/main/java/icu/samnyan/aqua/sega/maimai2/model/userdata/UserEntities.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/maimai2/model/userdata/UserEntities.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import icu.samnyan.aqua.net.games.BaseEntity
 import icu.samnyan.aqua.net.games.IGenericGamePlaylog
+import icu.samnyan.aqua.net.games.IGenericUserMusic
 import icu.samnyan.aqua.net.games.IUserEntity
 import icu.samnyan.aqua.sega.general.IntegerListConverter
 import jakarta.persistence.*
@@ -294,9 +295,9 @@ class Mai2UserMap : Mai2UserEntity() {
 
 @Table(name = "maimai2_user_music_detail")
 @Data @Entity
-class Mai2UserMusicDetail : Mai2UserEntity() {
+class Mai2UserMusicDetail : Mai2UserEntity(), IGenericUserMusic {
 
-    var musicId = 0
+    override var musicId = 0
     var level = 0
     var playCount = 0
     var achievement = 0

--- a/src/main/java/icu/samnyan/aqua/sega/ongeki/dao/userdata/UserMusicDetailRepository.java
+++ b/src/main/java/icu/samnyan/aqua/sega/ongeki/dao/userdata/UserMusicDetailRepository.java
@@ -1,5 +1,6 @@
 package icu.samnyan.aqua.sega.ongeki.dao.userdata;
 
+import icu.samnyan.aqua.net.games.GenericUserMusicRepo;
 import icu.samnyan.aqua.sega.ongeki.model.userdata.UserData;
 import icu.samnyan.aqua.sega.ongeki.model.userdata.UserMusicDetail;
 import org.springframework.data.domain.Page;
@@ -15,7 +16,7 @@ import java.util.Optional;
  * @author samnyan (privateamusement@protonmail.com)
  */
 @Repository("OngekiUserMusicDetailRepository")
-public interface UserMusicDetailRepository extends JpaRepository<UserMusicDetail, Long> {
+public interface UserMusicDetailRepository extends JpaRepository<UserMusicDetail, Long>, GenericUserMusicRepo<UserMusicDetail> {
 
     List<UserMusicDetail> findByUser_Card_ExtId(long userId);
 

--- a/src/main/java/icu/samnyan/aqua/sega/ongeki/model/userdata/UserMusicDetail.java
+++ b/src/main/java/icu/samnyan/aqua/sega/ongeki/model/userdata/UserMusicDetail.java
@@ -2,6 +2,7 @@ package icu.samnyan.aqua.sega.ongeki.model.userdata;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import icu.samnyan.aqua.net.games.IGenericUserMusic;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,7 +18,7 @@ import java.io.Serializable;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserMusicDetail implements Serializable {
+public class UserMusicDetail implements Serializable, IGenericUserMusic {
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/icu/samnyan/aqua/sega/wacca/model/db/Repos.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/wacca/model/db/Repos.kt
@@ -2,6 +2,7 @@ package icu.samnyan.aqua.sega.wacca.model.db
 
 import icu.samnyan.aqua.net.games.GenericPlaylogRepo
 import icu.samnyan.aqua.net.games.GenericUserDataRepo
+import icu.samnyan.aqua.net.games.GenericUserMusicRepo
 import jakarta.transaction.Transactional
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -32,7 +33,7 @@ interface WcUserItemRepo : IWaccaUserLinked<WcUserItem> {
     fun findByUserAndType(user: WaccaUser, type: Int): List<WcUserItem>
     fun findByUserAndItemIdAndType(user: WaccaUser, itemId: Int, type: Int): WcUserItem?
 }
-interface WcUserBestScoreRepo : IWaccaUserLinked<WcUserScore> {
+interface WcUserBestScoreRepo : IWaccaUserLinked<WcUserScore>, GenericUserMusicRepo<WcUserScore> {
     fun findByUserAndMusicIdAndLevel(user: WaccaUser, songId: Int, level: Int): WcUserScore?
     @Query("SELECT SUM(achievement) FROM WcUserScore WHERE user = :user")
     fun sumScoreByUser(user: WaccaUser): Long

--- a/src/main/java/icu/samnyan/aqua/sega/wacca/model/db/WaccaUserModels.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/wacca/model/db/WaccaUserModels.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import ext.*
 import icu.samnyan.aqua.net.games.BaseEntity
 import icu.samnyan.aqua.net.games.IGenericGamePlaylog
+import icu.samnyan.aqua.net.games.IGenericUserMusic
 import icu.samnyan.aqua.sega.general.IntegerListConverter
 import icu.samnyan.aqua.sega.wacca.WaccaItemType
 import icu.samnyan.aqua.sega.wacca.WaccaItemType.*
@@ -92,8 +93,8 @@ class WcUserItem(
 }
 
 @Entity @Table(name = "wacca_user_score", uniqueConstraints = [UC("", ["user_id", "music_id", "level"])])
-class WcUserScore : WaccaUserEntity() {
-    var musicId = 0
+class WcUserScore : WaccaUserEntity(), IGenericUserMusic {
+    override var musicId = 0
     var level = 0 // aka difficulty
     var achievement = 0
 


### PR DESCRIPTION
…usicRepo

## Summary by Sourcery

重构用户音乐检索逻辑，将其从单个游戏控制器移动到 `GameApiController`，并引入通用的 `GenericUserMusicRepo` 接口。

新特性：
- 添加新的 API 端点，根据音乐 ID 列表检索用户音乐数据。

增强：
- 引入 `GenericUserMusic` 接口和 `GenericUserMusicRepo`，以处理不同游戏中的用户音乐数据。
- 将 `userMusicFromList` API 端点移动到 `GameApiController`，提供集中的实现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the user music retrieval logic by moving it from individual game controllers to the `GameApiController` and introducing a generic `GenericUserMusicRepo` interface.

New Features:
- Add a new API endpoint to retrieve user music data based on a list of music IDs.

Enhancements:
- Introduce a `GenericUserMusic` interface and `GenericUserMusicRepo` to handle user music data across different games.
- Move the `userMusicFromList` API endpoint to the `GameApiController` to provide a centralized implementation.

</details>