### PR TITLE
[F] Mai2 music ranking fix

### DIFF
--- a/src/main/java/icu/samnyan/aqua/sega/maimai2/handler/GetGameRankingHandler.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/maimai2/handler/GetGameRankingHandler.kt
@@ -2,7 +2,6 @@ package icu.samnyan.aqua.sega.maimai2.handler
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import ext.logger
-import ext.thread
 import icu.samnyan.aqua.sega.general.BaseHandler
 import icu.samnyan.aqua.sega.maimai2.model.userdata.QMai2UserPlaylog
 import org.springframework.scheduling.annotation.Scheduled
@@ -26,7 +25,7 @@ class GetGameRankingHandler(
     init {
         // To make sure the cache is initialized before the first request,
         // not using `initialDelay = 0` in `@Scheduled`.
-        thread { refreshMusicRankingCache() }
+        refreshMusicRankingCache()
     }
 
     @Scheduled(fixedDelay = 3600_000)

--- a/src/main/java/icu/samnyan/aqua/sega/maimai2/handler/GetGameRankingHandler.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/maimai2/handler/GetGameRankingHandler.kt
@@ -2,6 +2,7 @@ package icu.samnyan.aqua.sega.maimai2.handler
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import ext.logger
+import ext.thread
 import icu.samnyan.aqua.sega.general.BaseHandler
 import icu.samnyan.aqua.sega.maimai2.model.userdata.QMai2UserPlaylog
 import org.springframework.scheduling.annotation.Scheduled
@@ -25,7 +26,7 @@ class GetGameRankingHandler(
     init {
         // To make sure the cache is initialized before the first request,
         // not using `initialDelay = 0` in `@Scheduled`.
-        refreshMusicRankingCache()
+        thread { refreshMusicRankingCache() }
     }
 
     @Scheduled(fixedDelay = 3600_000)

--- a/src/main/java/icu/samnyan/aqua/sega/maimai2/handler/GetGameRankingHandler.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/maimai2/handler/GetGameRankingHandler.kt
@@ -17,7 +17,7 @@ import kotlin.concurrent.Volatile
 class GetGameRankingHandler(
     private val queryFactory: JPAQueryFactory
 ) : BaseHandler {
-    private data class MusicRankingItem(val id: Int, val point: Long, val userName: String = "")
+    private data class MusicRankingItem(val musicId: Int, val weight: Long)
 
     @Volatile
     private var musicRankingCache: List<MusicRankingItem> = emptyList()
@@ -54,7 +54,7 @@ class GetGameRankingHandler(
     override fun handle(request: Map<String, Any>): Any = mapOf(
         "type" to request["type"],
         "gameRankingList" to when(request["type"]) {
-            1 -> musicRankingCache
+            1 -> musicRankingCache.map { mapOf("id" to it.musicId, "point" to it.weight, "userName" to "") }
             else -> emptyList()
         }
     )


### PR DESCRIPTION
1. Music ranking cache *must* be available *before* the server able to server a request. So, initialize in a thread breaks the correctness.
2. `point` and `userName` are the game client's wrong field names. Don't spread the misleading wrong field names across the border of serialization.

## Summary by Sourcery

修复音乐排名缓存的初始化，使其在处理请求之前发生，并更正音乐排名数据结构中的字段名称。

Bug 修复：
- 通过移除异步初始化，确保在服务器处理请求之前初始化音乐排名缓存。

增强：
- 更正音乐排名数据结构中的字段名称，避免传播不正确的客户端字段名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the initialization of the music ranking cache to occur before handling requests and correct field names in the music ranking data structure.

Bug Fixes:
- Ensure music ranking cache is initialized before the server handles requests by removing asynchronous initialization.

Enhancements:
- Correct field names in the music ranking data structure to avoid spreading incorrect client field names.

</details>