### PR TITLE
[+] Allow disable music rank for own machine

### DIFF
--- a/AquaNet/src/components/settings/Mai2Settings.svelte
+++ b/AquaNet/src/components/settings/Mai2Settings.svelte
@@ -5,6 +5,7 @@
   import Icon from "@iconify/svelte";
   import StatusOverlays from "../StatusOverlays.svelte";
   import { GAME } from "../../libs/sdk";
+  import GameSettingFields from "./GameSettingFields.svelte";
 
   const profileFields = [
     ['name', t('settings.mai2.name')],
@@ -72,6 +73,7 @@
       </div>
     </div>
   {/each}
+  <GameSettingFields game="mai2"/>
   <button class="exportButton" on:click={exportData}>
     <Icon icon="bxs:file-export"/>
     {t('settings.export')}

--- a/AquaNet/src/libs/i18n/en_ref.ts
+++ b/AquaNet/src/libs/i18n/en_ref.ts
@@ -153,6 +153,8 @@ export const EN_REF_SETTINGS = {
   'settings.fields.gameUsername.desc': 'Your name shown in game',
   'settings.fields.optOutOfLeaderboard.name': 'Opt Out of Leaderboard',
   'settings.fields.optOutOfLeaderboard.desc': 'You will still be able to see yourself on the leaderboard after logging in',
+  'settings.fields.enableMusicRank.name': 'Enable Recommended Music Rank on Your Machine',
+  'settings.fields.enableMusicRank.desc': 'If you have your own ranking, you can turn this off. It only affects your own machine',
   'settings.mai2.name': 'Player Name',
   'settings.profile.picture': 'Profile Picture',
   'settings.profile.upload-new': 'Upload New',

--- a/AquaNet/src/libs/i18n/zh.ts
+++ b/AquaNet/src/libs/i18n/zh.ts
@@ -163,6 +163,8 @@ const zhSettings: typeof EN_REF_SETTINGS = {
   'settings.fields.gameUsername.desc': '在游戏中显示的用户名',
   'settings.fields.optOutOfLeaderboard.name': '不参与排行榜',
   'settings.fields.optOutOfLeaderboard.desc': '登录之后还是可以在排行榜上看到自己',
+  'settings.fields.enableMusicRank.name': '在你的机台上启用“推荐乐曲排行榜”',
+  'settings.fields.enableMusicRank.desc': '如果你自己设计了排行榜的话，可以关闭这个。只会影响你自己的机器',
   'settings.mai2.name': '玩家名字',
   'settings.profile.picture': '头像',
   'settings.profile.upload-new': '上传',

--- a/src/main/java/icu/samnyan/aqua/net/db/AquaGameOptions.kt
+++ b/src/main/java/icu/samnyan/aqua/net/db/AquaGameOptions.kt
@@ -43,6 +43,9 @@ class AquaGameOptions(
 
     @SettingField("chu3-matching")
     var chusanMatchingReflector: String = "",
+
+    @SettingField("mai2")
+    var enableMusicRank: Boolean = true,
 )
 
 interface AquaGameOptionsRepo : JpaRepository<AquaGameOptions, Long>

--- a/src/main/java/icu/samnyan/aqua/sega/maimai2/handler/GetGameRankingHandler.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/maimai2/handler/GetGameRankingHandler.kt
@@ -58,7 +58,8 @@ class GetGameRankingHandler(
         "gameRankingList" to when(request["type"]) {
             1 -> {
                 val opts = TokenChecker.getCurrentSession()?.user?.gameOptions
-                if (opts?.enableMusicRank != true)
+                // If is null or true, return the ranking list
+                if (opts?.enableMusicRank == false)
                     emptyList()
                 else
                     musicRankingCache.map { mapOf("id" to it.musicId, "point" to it.weight, "userName" to "") }

--- a/src/main/java/icu/samnyan/aqua/sega/maimai2/handler/GetGameRankingHandler.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/maimai2/handler/GetGameRankingHandler.kt
@@ -3,6 +3,7 @@ package icu.samnyan.aqua.sega.maimai2.handler
 import com.querydsl.jpa.impl.JPAQueryFactory
 import ext.logger
 import ext.thread
+import icu.samnyan.aqua.sega.allnet.TokenChecker
 import icu.samnyan.aqua.sega.general.BaseHandler
 import icu.samnyan.aqua.sega.maimai2.model.userdata.QMai2UserPlaylog
 import org.springframework.scheduling.annotation.Scheduled
@@ -55,7 +56,13 @@ class GetGameRankingHandler(
     override fun handle(request: Map<String, Any>): Any = mapOf(
         "type" to request["type"],
         "gameRankingList" to when(request["type"]) {
-            1 -> musicRankingCache.map { mapOf("id" to it.musicId, "point" to it.weight, "userName" to "") }
+            1 -> {
+                val opts = TokenChecker.getCurrentSession()?.user?.gameOptions
+                if (opts?.enableMusicRank != true)
+                    emptyList()
+                else
+                    musicRankingCache.map { mapOf("id" to it.musicId, "point" to it.weight, "userName" to "") }
+            }
             else -> emptyList()
         }
     )

--- a/src/main/resources/db/V1000_35__maimai2_optional_music_rank.sql
+++ b/src/main/resources/db/V1000_35__maimai2_optional_music_rank.sql
@@ -1,0 +1,1 @@
+ALTER TABLE aqua_game_options ADD enable_music_rank BIT(1) NOT NULL DEFAULT 1;


### PR DESCRIPTION
支持通过设置更改是否要给自己的机器显示推荐乐曲排行榜

因为我本地的数据貌似不够生成排行榜所以没有完全测试

## Summary by Sourcery

允许禁用用户自己机器上的推荐音乐排名。

新功能：
- 添加选项以禁用在用户机器上显示的推荐音乐排名。

测试：
- 由于本地数据不足，仅进行部分测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow disabling the recommended music rank for a user's own machine.

New Features:
- Add an option to disable the recommended music rank displayed on a user's machine.

Tests:
- Partially tested due to insufficient local data.

</details>