### PR TITLE
[+] Know game version from user-name-plate query

### DIFF
--- a/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
@@ -85,6 +85,8 @@ class Maimai2(
     suspend fun userNamePlate(@RP username: Str) = us.cardByName(username) { card ->
         val userData = repos.userData.findByCardExtId(card.extId).orElse(null) ?: (404 - "User not found")
         mapOf(
+            "lastGameId" to userData.lastGameId,
+            "lastRomVersion" to userData.lastRomVersion,
             "iconId" to userData.iconId,
             "plateId" to userData.plateId,
             "titleId" to userData.titleId,


### PR DESCRIPTION
Sometimes nameplate appears differ in different game versions (e.g. the same title ID displays different string). Include them in the `/user-name-plate` API query.

## Summary by Sourcery

新功能：
- 在 `/user-name-plate` API 响应中添加 `lastGameId` 和 `lastRomVersion`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add `lastGameId` and `lastRomVersion` to the `/user-name-plate` API response.

</details>