### PR TITLE
BUG: Fix gradlew not being executable during docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ WORKDIR /home/gradle
 RUN sed -i 's/\r$//' ./gradlew
 
 # Download dependencies - cached if build.gradle.kts and settings.gradle.kts are unchanged
+RUN chmod +x ./gradlew
 RUN ./gradlew dependencies
 
 # Copy the project source, this layer is rebuilt whenever a file has changed


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change ensures that the `gradlew` script has execute permissions before running it.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R18): Added a command to change the permissions of the `gradlew` script to make it executable.

## Summary by Sourcery

在 Docker 构建期间使 gradlew 可执行。

Bug 修复：
- 修复了 Docker 构建过程中 gradlew 无法执行的问题。

构建：
- 修改 Dockerfile 以使 gradlew 可执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make gradlew executable during the Docker build.

Bug Fixes:
- Fixed an issue where gradlew was not executable during the Docker build process.

Build:
- Modified the Dockerfile to make gradlew executable.

</details>