### PR TITLE
Modify the Chu3 rating return accuracy

### DIFF
--- a/AquaNet/src/libs/scoring.ts
+++ b/AquaNet/src/libs/scoring.ts
@@ -135,7 +135,7 @@ export function parseComposition(item: string, allMusics: Record<string, MusicMe
     if (game === 'mai2')
       return Math.floor(diff * mult * (Math.min(100.5, score / 10000) / 100)).toFixed(0)
     if (game === 'chu3')
-      return (chusanRating(diff, score) / 100).toFixed(1)
+      return (Math.floor(chusanRating(diff, score)) / 100).toFixed(2)
   }
 
   return {

--- a/docs/aquabox-url-mode.md
+++ b/docs/aquabox-url-mode.md
@@ -16,7 +16,7 @@
 
     It is recommended you have the latest version of the game and all of the options your users may use.
 
-    The script to generate the proper paths can be found in [tools/chusan-extractor.js](tools/chusan-extractor.js). Node.js or Bun is required.<br>
+    The script to generate the proper paths can be found in [tools/extract-chusan.js](../tools/extract-chusan.js). Node.js or Bun is required.<br>
     Please read the comments at the top of the script for usage instructions.
 
 2. Copy the new `chu3` folder where you need it to be (read #3 if you're hosting AquaNet and want to host on the same endpoints).


### PR DESCRIPTION
[#126](https://github.com/MewoLab/AquaDX/issues/126#issuecomment-2723684886)
Rounding one decimal place of the original Chu3 rating result is replaced with two decimal places of unconditional rounding.
![image](https://github.com/user-attachments/assets/79cc7f54-c15d-443c-a5f3-5653c9a1c69e)

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

增强：
- 更新 Chu3 评分计算，将结果四舍五入到小数点后两位。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update the Chu3 rating calculation to round the result to two decimal places.

</details>