### PR TITLE
server/webui: symbol chat

### DIFF
--- a/AquaNet/src/components/settings/ChuniMatchingSettings.svelte
+++ b/AquaNet/src/components/settings/ChuniMatchingSettings.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { fade } from "svelte/transition";
+  import { fade, slide } from "svelte/transition";
   import { CHU3_MATCHINGS } from "../../libs/config.js";
   import type { ChusanMatchingOption, GameOption } from "../../libs/generalTypes.js";
-import { t } from "../../libs/i18n.js";
-  import { SETTING } from "../../libs/sdk.js";
+  import { t, ts } from "../../libs/i18n.js";
+  import { DATA, SETTING } from "../../libs/sdk.js";
   import StatusOverlays from "../StatusOverlays.svelte";
   import GameSettingFields from "./GameSettingFields.svelte";
 
@@ -12,14 +12,42 @@ import { t } from "../../libs/i18n.js";
   let loading = false
   let error = ""
 
-  let existingUrl = ""
+  let changed: string[] = [];
+  let symbols: Record<number, number> = {};
+  let allItems: Record<string, Record<string, { name: string }>> = {}
+  let submitting: string | undefined | null;  
+
+  let existingUrl = "";
   SETTING.get().then(s => {
     existingUrl = s.filter(it => it.key === 'chusanMatchingServer')[0]?.value
 
     if (existingUrl && !CHU3_MATCHINGS.some(it => it.matching === existingUrl)) {
       custom = true
     }
+
+    const symbolKey = "chusanSymbolChat"
+    s.forEach(opt => {
+      if (opt.key.substring(0, symbolKey.length) == symbolKey && opt.value)
+        symbols[parseInt(opt.key.substring(symbolKey.length))] = opt.value;
+    })
   })
+
+  async function fetchSymbolData() {
+    allItems = await DATA.allItems('chu3').catch(_ => {
+      loading = false
+      error = t("userbox.error.nodata")
+    }) as typeof allItems
+  }
+
+  async function submitSymbol(id: number) {
+    if (submitting) return false
+    const field = `chusanSymbolChat${id + 1}`;
+    submitting = field
+
+    await SETTING.set(field, symbols[id + 1]).catch(e => error = e.message).finally(() => submitting = null);
+    changed = changed.filter(v => v != `symbolChat${id}`)
+    return true
+  }
 
   // Click on "Custom" option"
   function clickCustom() {
@@ -53,6 +81,28 @@ import { t } from "../../libs/i18n.js";
   {#if custom}
     <GameSettingFields game="chu3-matching"/>
   {/if}
+
+  <h2>{t("userbox.header.matching.symbolChat")}</h2>
+  {#await fetchSymbolData() then}
+    {#each {length: 4}, i}
+      <div class="field">
+        <label for={`symbolChat${i}`}>{ts(`userbox.matching.symbolChat`) + ` #${i + 1}`}</label>
+        <div>
+          <select bind:value={symbols[i + 1]} id={`symbolChat${i}`} on:change={() => {changed = [...changed, `symbolChat${i}`];}}>
+            <option value={null}>{ts(`userbox.matching.symbolChat.default`)}</option>
+            {#each Object.entries(allItems.symbolChat).filter((f) => parseInt(f[0]) !== 0) as [id, option]}
+              <option value={parseInt(id)}>{option?.name || `(unknown ${id})`}</option>
+            {/each}
+          </select>
+          {#if changed.includes(`symbolChat${i}`)}
+            <button transition:slide={{axis: "x"}} disabled={!!submitting} on:click={() => submitSymbol(i)}>
+              {t("settings.profile.save")}
+            </button>
+          {/if}
+        </div>
+      </div>
+    {/each}
+  {/await}
 </div>
 
 {#if overlay}

--- a/AquaNet/src/components/settings/ChuniMatchingSettings.svelte
+++ b/AquaNet/src/components/settings/ChuniMatchingSettings.svelte
@@ -45,7 +45,7 @@
     submitting = field
 
     await SETTING.set(field, symbols[id + 1]).catch(e => error = e.message).finally(() => submitting = null);
-    changed = changed.filter(v => v != `symbolChat${id}`)
+    changed = changed.filter(v => v != `chusanSymbolChat${id}`)
     return true
   }
 
@@ -86,15 +86,15 @@
   {#await fetchSymbolData() then}
     {#each {length: 4}, i}
       <div class="field">
-        <label for={`symbolChat${i}`}>{ts(`userbox.matching.symbolChat`) + ` #${i + 1}`}</label>
+        <label for={`chusanSymbolChat${i}`}>{ts(`userbox.matching.symbolChat`) + ` #${i + 1}`}</label>
         <div>
-          <select bind:value={symbols[i + 1]} id={`symbolChat${i}`} on:change={() => {changed = [...changed, `symbolChat${i}`];}}>
+          <select bind:value={symbols[i + 1]} id={`chusanSymbolChat${i}`} on:change={() => {changed = [...changed, `chusanSymbolChat${i}`];}}>
             <option value={null}>{ts(`userbox.matching.symbolChat.default`)}</option>
             {#each Object.entries(allItems.symbolChat).filter((f) => parseInt(f[0]) !== 0) as [id, option]}
               <option value={parseInt(id)}>{option?.name || `(unknown ${id})`}</option>
             {/each}
           </select>
-          {#if changed.includes(`symbolChat${i}`)}
+          {#if changed.includes(`chusanSymbolChat${i}`)}
             <button transition:slide={{axis: "x"}} disabled={!!submitting} on:click={() => submitSymbol(i)}>
               {t("settings.profile.save")}
             </button>

--- a/AquaNet/src/libs/i18n/en_ref.ts
+++ b/AquaNet/src/libs/i18n/en_ref.ts
@@ -190,6 +190,7 @@ export const EN_REF_SETTINGS = {
 export const EN_REF_USERBOX = {
   'userbox.header.general': 'General Settings',
   'userbox.header.matching': 'National Matching',
+  'userbox.header.matching.symbolChat': 'Chat Symbols (Matching)',
   'userbox.header.userbox': 'UserBox Settings',
   'userbox.header.preview': 'UserBox Preview',
   'userbox.nameplateId': 'Nameplate',
@@ -216,6 +217,8 @@ export const EN_REF_USERBOX = {
   'userbox.matching.option.collab': 'Collaborators',
   'userbox.matching.custom.name': 'Custom',
   'userbox.matching.custom.sub': 'Enter your own URL',
+  'userbox.matching.symbolChat': 'Message Choice',
+  'userbox.matching.symbolChat.default': 'Default',
 
   'userbox.new.name': 'AquaBox',
   'userbox.new.setup': 'Drag and drop your Chuni game folder (Lumi or newer) into the box below to display UserBoxes with their nameplate & avatar. All files are handled in-browser.',

--- a/AquaNet/src/libs/i18n/zh.ts
+++ b/AquaNet/src/libs/i18n/zh.ts
@@ -84,6 +84,11 @@ const zhGeneral: typeof EN_REF_GENERAL = {
   "action.refresh": "刷新",
   "action.cancel": "取消",
   "action.confirm": "确认",
+  'navigation.profile': '个人资料',
+  'navigation.maps': '地图',
+  'navigation.home': '首页',
+  'navigation.rankings': '排行榜',
+  'navigation.notice': '公告'
 }
 
 const zhHome: typeof EN_REF_HOME = {
@@ -197,6 +202,7 @@ const zhSettings: typeof EN_REF_SETTINGS = {
 export const zhUserbox: typeof EN_REF_USERBOX = {
   'userbox.header.general': '游戏设置',
   'userbox.header.matching': '全国对战',
+  'userbox.header.matching.symbolChat': '全国对战聊天表情',
   'userbox.header.userbox': 'UserBox 设置',
   'userbox.header.preview': 'UserBox 预览',
   'userbox.nameplateId': '名牌',
@@ -223,6 +229,8 @@ export const zhUserbox: typeof EN_REF_USERBOX = {
   'userbox.matching.option.collab': '合作伙伴',
   'userbox.matching.custom.name': '自定义',
   'userbox.matching.custom.sub': '输入其他的匹配 URL',
+  'userbox.matching.symbolChat': '表情选择',
+  'userbox.matching.symbolChat.default': '默认',
 
   'userbox.new.name': 'AquaBox',
   'userbox.new.setup': '将中二（Lumi 或更高版本）的游戏文件夹拖放到下方区域，以显示带有名牌和头像的 UserBox。所有文件都在浏览器中处理。',

--- a/src/main/java/icu/samnyan/aqua/net/db/AquaGameOptions.kt
+++ b/src/main/java/icu/samnyan/aqua/net/db/AquaGameOptions.kt
@@ -43,6 +43,15 @@ class AquaGameOptions(
 
     @SettingField("chu3-matching")
     var chusanMatchingReflector: String = "",
+    
+    @SettingField("chu3-matching-chat")
+    var chusanSymbolChat1: Int? = null,
+    @SettingField("chu3-matching-chat")
+    var chusanSymbolChat2: Int? = null,
+    @SettingField("chu3-matching-chat")
+    var chusanSymbolChat3: Int? = null,
+    @SettingField("chu3-matching-chat")
+    var chusanSymbolChat4: Int? = null,
 
     @SettingField("mai2")
     var enableMusicRank: Boolean = true,

--- a/src/main/java/icu/samnyan/aqua/sega/chusan/handler/ChusanApis.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/chusan/handler/ChusanApis.kt
@@ -84,7 +84,6 @@ fun ChusanController.chusanInit() {
     "GetUserRivalData" { """{"userId":"${data["userId"]}","length":"0","userRivalData":[]}""" }
     "GetUserRegion" { """{"userId":"${data["userId"]}","length":"0","userRegionList":[]}""" }
     "GetUserPrintedCard" { """{"userId":"${data["userId"]}","length":0,"nextIndex":-1,"userPrintedCardList":[]}""" }
-    "GetUserSymbolChatSetting" { """{"userId":"${data["userId"]}","length":"0","symbolChatInfoList":[]}""" }
 
     // Net battle data
     "GetUserNetBattleData" api@ {
@@ -97,6 +96,21 @@ fun ChusanController.chusanInit() {
         ))
     }
     "GetUserNetBattleRankingInfo" { """{"userId":"${data["userId"]}","length":"0","userNetBattleRankingInfoList":{}}""" }
+
+    "GetUserSymbolChatSetting".paged("symbolChatInfoList") {
+        fun Int.makeSymbols(order: Int) = (1..5).map {
+            mapOf(
+                "sceneId" to it,
+                "symbolChatId" to this,
+                "orderId" to order
+            )
+        }
+
+        db.userData.findByCard_ExtId(uid)()?.card?.aquaUser?.gameOptions?.run {
+            listOf(chusanSymbolChat1, chusanSymbolChat2, chusanSymbolChat3, chusanSymbolChat4)
+                .flatMapIndexed { i, sym -> sym?.makeSymbols(i) ?: empty }
+        } ?: empty
+    }
 
     // User handlers
     "GetUserData" {

--- a/src/main/resources/db/80/V1000_47__chusan_symbol_chat.sql
+++ b/src/main/resources/db/80/V1000_47__chusan_symbol_chat.sql
@@ -1,0 +1,5 @@
+ALTER TABLE aqua_game_options 
+ADD chusan_symbol_chat1 MEDIUMINT NULL,
+ADD chusan_symbol_chat2 MEDIUMINT NULL,
+ADD chusan_symbol_chat3 MEDIUMINT NULL,
+ADD chusan_symbol_chat4 MEDIUMINT NULL;


### PR DESCRIPTION
new:
 - api is no longer stubbed for symbolchat (ty aza for cleaning my impl up)
 - db keys for symbolchat (kind of jank sorry)
 - added symbolchat options to aquanet
 - added chinese and english i18n for symbolchat options

upd:
 - no chinese translations for the navigation bar, added now

好的，这是将拉取请求摘要翻译成中文的结果：

## Sourcery 总结

为 Chunithm 匹配设置实现符号聊天功能，允许用户选择自定义聊天符号，并添加必要的后端和前端支持。

新功能：
- 为 Chunithm 匹配添加符号聊天配置选项
- 在用户界面中实现动态符号聊天选择

增强功能：
- 扩展数据库模式以支持符号聊天设置
- 为符号聊天选项添加动态数据获取

CI：
- 为符号聊天配置添加数据库迁移脚本

文档：
- 为符号聊天设置添加中文和英文翻译

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement Symbol Chat feature for Chunithm matching settings, allowing users to select custom chat symbols and adding necessary backend and frontend support

New Features:
- Add Symbol Chat configuration options for Chunithm matching
- Implement dynamic Symbol Chat selection in the user interface

Enhancements:
- Extend database schema to support Symbol Chat settings
- Add dynamic data fetching for Symbol Chat options

CI:
- Add database migration script for Symbol Chat configuration

Documentation:
- Add Chinese and English translations for Symbol Chat settings

</details>