### PR TITLE
Migrate from / to /confirm for Email Confirmation

### DIFF
--- a/AquaNet/src/App.svelte
+++ b/AquaNet/src/App.svelte
@@ -79,6 +79,7 @@
 
 <Router {url}>
   <Route path="/" component={Welcome} />
+  <Route path="/confirm" component={Welcome} /> <!-- For email confirmation only, backwards compatibility with AquaNet2 in the future -->
   <Route path="/home" component={Home} />
   <Route path="/ranking" component={Ranking} />
   <Route path="/ranking/:game" component={Ranking} />

--- a/AquaNet/src/App.svelte
+++ b/AquaNet/src/App.svelte
@@ -79,7 +79,7 @@
 
 <Router {url}>
   <Route path="/" component={Welcome} />
-  <Route path="/confirm" component={Welcome} /> <!-- For email confirmation only, backwards compatibility with AquaNet2 in the future -->
+  <Route path="/verify" component={Welcome} /> <!-- For email verification only, backwards compatibility with AquaNet2 in the future -->
   <Route path="/home" component={Home} />
   <Route path="/ranking" component={Ranking} />
   <Route path="/ranking/:game" component={Ranking} />

--- a/AquaNet/src/pages/Welcome.svelte
+++ b/AquaNet/src/pages/Welcome.svelte
@@ -25,16 +25,16 @@
     window.location.href = "/home"
   }
 if (location.pathname !== '/') {
-    location.href = `/${params.get('confirm-email') ? `?confirm-email=${params.get('confirm-email')}` : ""}`
+    location.href = `/${params.get('code') ? `?code=${params.get('code')}` : ""}`
   } else
-    if (params.get('confirm-email')) {
+    if (params.get('code')) {
 
       state = 'verify'
       verifyMsg = t("welcome.verifying")
       submitting = true
 
       // Send request to server
-      USER.confirmEmail(params.get('confirm-email')!)
+      USER.confirmEmail(params.get('code')!)
         .then(() => {
           verifyMsg = t('welcome.verified')
           submitting = false

--- a/AquaNet/src/pages/Welcome.svelte
+++ b/AquaNet/src/pages/Welcome.svelte
@@ -24,23 +24,26 @@
   if (USER.isLoggedIn()) {
     window.location.href = "/home"
   }
+if (location.pathname !== '/') {
+    location.href = `/${params.get('confirm-email') ? `?confirm-email=${params.get('confirm-email')}` : ""}`
+  } else
+    if (params.get('confirm-email')) {
 
-  if (params.get('confirm-email')) {
-    state = 'verify'
-    verifyMsg = t("welcome.verifying")
-    submitting = true
+      state = 'verify'
+      verifyMsg = t("welcome.verifying")
+      submitting = true
 
-    // Send request to server
-    USER.confirmEmail(params.get('confirm-email')!)
-      .then(() => {
-        verifyMsg = t('welcome.verified')
-        submitting = false
+      // Send request to server
+      USER.confirmEmail(params.get('confirm-email')!)
+        .then(() => {
+          verifyMsg = t('welcome.verified')
+          submitting = false
 
-        // Clear the query param
-        window.history.replaceState({}, document.title, window.location.pathname)
-      })
-      .catch(e => verifyMsg = t('welcome.verification-failed', { message: e.message }))
-  }
+          // Clear the query param
+          window.history.replaceState({}, document.title, window.location.pathname)
+        })
+        .catch(e => verifyMsg = t('welcome.verification-failed', { message: e.message }))
+    }
 
   async function submit(): Promise<any> {
     submitting = true

--- a/src/main/java/icu/samnyan/aqua/net/components/Email.kt
+++ b/src/main/java/icu/samnyan/aqua/net/components/Email.kt
@@ -76,7 +76,7 @@ class EmailService(
             .withSubject("Confirm Your Email Address for AquaNet")
             .withHTMLText(confirmTemplate
                 .replace("{{name}}", user.computedName)
-                .replace("{{url}}", "https://${props.webHost}?confirm-email=$token"))
+                .replace("{{url}}", "https://${props.webHost}/confirm?confirm-email=$token"))
             .buildEmail()).thenRun { log.info("Confirmation email sent to ${user.email}") }
     }
 

--- a/src/main/java/icu/samnyan/aqua/net/components/Email.kt
+++ b/src/main/java/icu/samnyan/aqua/net/components/Email.kt
@@ -69,15 +69,15 @@ class EmailService(
         confirmationRepo.save(confirmation)
 
         // Send email
-        log.info("Sending confirmation email to ${user.email}")
+        log.info("Sending verification email to ${user.email}")
         mailer.sendMail(EmailBuilder.startingBlank()
             .from(props.senderName, props.senderAddr)
             .to(user.computedName, user.email)
-            .withSubject("Confirm Your Email Address for AquaNet")
+            .withSubject("Verification Your Email Address for AquaNet")
             .withHTMLText(confirmTemplate
                 .replace("{{name}}", user.computedName)
-                .replace("{{url}}", "https://${props.webHost}/confirm?confirm-email=$token"))
-            .buildEmail()).thenRun { log.info("Confirmation email sent to ${user.email}") }
+                .replace("{{url}}", "https://${props.webHost}/verify?code=$token"))
+            .buildEmail()).thenRun { log.info("Verification email sent to ${user.email}") }
     }
 
     fun testEmail(addr: Str, name: Str) {

--- a/src/main/resources/email/confirm.html
+++ b/src/main/resources/email/confirm.html
@@ -212,7 +212,7 @@
                         <div style="color:#101112;direction:ltr;font-family:'Montserrat', 'Trebuchet MS', 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', Tahoma, sans-serif;font-size:16px;font-weight:400;letter-spacing:0px;line-height:120%;text-align:left;mso-line-height-alt:19.2px;">
                           <p style="margin: 0; margin-bottom: 16px;">Dear {{name}},</p>
                           <p style="margin: 0; margin-bottom: 16px;">Thank you for registering with AquaDX! We're excited to have you on board. To complete your registration and verify your email address, please click the link below.</p>
-                          <p style="margin: 0;">This link will confirm your email address, and it is valid for 24 hours. If you did not initiate this request, please ignore this email.</p>
+                          <p style="margin: 0;">This link will verify your email address, and it is valid for 24 hours. If you did not initiate this request, please ignore this email.</p>
                         </div>
                       </td>
                     </tr>
@@ -225,7 +225,7 @@
                             <w:anchorlock/>
                             <v:textbox inset="0px,0px,0px,0px">
                               <center style="color:#ffffff; font-family:'Trebuchet MS', Tahoma, sans-serif; font-size:16px">
-                          <![endif]--><a href="{{url}}" style="text-decoration:none;display:inline-block;color:#ffffff;background-color:#646cff;border-radius:8px;width:auto;border-top:0px solid transparent;font-weight:400;border-right:0px solid transparent;border-bottom:0px solid transparent;border-left:0px solid transparent;padding-top:8px;padding-bottom:8px;font-family:'Montserrat', 'Trebuchet MS', 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', Tahoma, sans-serif;font-size:16px;text-align:center;mso-border-alt:none;word-break:keep-all;" target="_blank"><span style="padding-left:16px;padding-right:16px;font-size:16px;display:inline-block;letter-spacing:normal;"><span style="word-break: break-word; line-height: 32px;">Confirm email</span></span></a><!--[if mso]></center></v:textbox></v:roundrect><![endif]--></div>
+                          <![endif]--><a href="{{url}}" style="text-decoration:none;display:inline-block;color:#ffffff;background-color:#646cff;border-radius:8px;width:auto;border-top:0px solid transparent;font-weight:400;border-right:0px solid transparent;border-bottom:0px solid transparent;border-left:0px solid transparent;padding-top:8px;padding-bottom:8px;font-family:'Montserrat', 'Trebuchet MS', 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', Tahoma, sans-serif;font-size:16px;text-align:center;mso-border-alt:none;word-break:keep-all;" target="_blank"><span style="padding-left:16px;padding-right:16px;font-size:16px;display:inline-block;letter-spacing:normal;"><span style="word-break: break-word; line-height: 32px;">Verify email</span></span></a><!--[if mso]></center></v:textbox></v:roundrect><![endif]--></div>
                       </td>
                     </tr>
                   </table>


### PR DESCRIPTION
It's not an elegant solution, it's only here so it's cleaner when we migrate to **AquaNet2** :heart:.

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将电子邮件确认流程迁移到专用的 `/confirm` 路径，同时保持与根路由的向后兼容性。

增强功能：
- 在 SPA 中添加 `/confirm` 路由，并将其映射到 Welcome 组件以进行电子邮件确认。
- 更新电子邮件服务以生成带有 `/confirm?confirm-email=<token>` 的确认 URL。
- 调整 Welcome 页面逻辑，以规范化和处理 `/` 和 `/confirm` 路由上的 `confirm-email` 查询参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate the email confirmation flow to use a dedicated `/confirm` path while preserving backwards compatibility with the root route.

Enhancements:
- Add `/confirm` route in the SPA and map it to the Welcome component for email confirmation.
- Update email service to generate confirmation URLs with `/confirm?confirm-email=<token>`.
- Adjust Welcome page logic to normalize and handle the `confirm-email` query parameter across `/` and `/confirm` routes.

</details>