### PR TITLE
[+] Add missing Mai2 export fields

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -30,7 +30,7 @@ allnet.server.redirect=https://aquadx.net
 ## Http Server Port
 ## Only change this if you have a reverse proxy running.
 ## The game rely on 80 port for boot up command
-server.port=80
+server.port=8080
 
 ## Static file server
 ## This is used to server static files in /web/ directory, which is Aquaviewer

--- a/config/application.properties
+++ b/config/application.properties
@@ -30,7 +30,7 @@ allnet.server.redirect=https://aquadx.net
 ## Http Server Port
 ## Only change this if you have a reverse proxy running.
 ## The game rely on 80 port for boot up command
-server.port=8080
+server.port=80
 
 ## Static file server
 ## This is used to server static files in /web/ directory, which is Aquaviewer

--- a/src/main/java/icu/samnyan/aqua/net/games/ImportController.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/ImportController.kt
@@ -58,7 +58,8 @@ abstract class ImportController<ExportModel: IExportClass<UserModel>, UserModel:
     val exportFields: Map<String, Var<ExportModel, Any>>,
     val exportRepos: Map<Var<ExportModel, Any>, IUserRepo<UserModel, *>>,
     val artemisRenames: Map<String, ImportClass<*>>,
-    val customExporters: Map<Var<ExportModel, Any>, (UserModel, ExportOptions) -> Any?> = emptyMap()
+    val customExporters: Map<Var<ExportModel, Any>, (UserModel, ExportOptions) -> Any?> = emptyMap(),
+    val customImporters: Map<Var<ExportModel, Any>, (ExportModel, UserModel) -> Unit> = emptyMap()
 ) {
     abstract fun createEmpty(): ExportModel
     abstract val userDataRepo: GenericUserDataRepo<UserModel>
@@ -105,8 +106,8 @@ abstract class ImportController<ExportModel: IExportClass<UserModel>, UserModel:
         val export = json.parseJackson(exportClass.java)
         if (!export.gameId.equals(game, true)) 400 - "Invalid game ID"
 
-        val lists = listRepos.toList().associate { (f, r) -> r to f.get(export) as List<IUserEntity<UserModel>> }.vNotNull()
-        val singles = singleRepos.toList().associate { (f, r) -> r to f.get(export) as IUserEntity<UserModel> }.vNotNull()
+        val lists = listRepos.toList().filter { (f, _) -> f !in customImporters }.associate { (f, r) -> r to f.get(export) as List<IUserEntity<UserModel>> }.vNotNull()
+        val singles = singleRepos.toList().filter { (f, _) -> f !in customImporters }.associate { (f, r) -> r to f.get(export) as IUserEntity<UserModel> }.vNotNull()
 
         // Validate new user data
         // Check that all ids are 0 (this should be true since all ids are @JsonIgnore)
@@ -138,6 +139,10 @@ abstract class ImportController<ExportModel: IExportClass<UserModel>, UserModel:
             // Save new data
             singles.forEach { (repo, single) -> (repo as IUserRepo<UserModel, Any>).save(single) }
             lists.forEach { (repo, list) -> (repo as IUserRepo<UserModel, Any>).saveAll(list) }
+            // Handle custom importers
+            customImporters.forEach { (field, importer) ->
+                importer(export, nu)
+            }
         }
 
         SUCCESS

--- a/src/main/java/icu/samnyan/aqua/net/games/ImportController.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/ImportController.kt
@@ -16,6 +16,10 @@ import kotlin.io.path.Path
 import kotlin.io.path.writeText
 import kotlin.reflect.KClass
 
+data class ExportOptions(
+    val playlogSince: String? = null
+)
+
 // Import class with renaming
 data class ImportClass<T : Any>(
     val type: KClass<T>,
@@ -54,6 +58,7 @@ abstract class ImportController<ExportModel: IExportClass<UserModel>, UserModel:
     val exportFields: Map<String, Var<ExportModel, Any>>,
     val exportRepos: Map<Var<ExportModel, Any>, IUserRepo<UserModel, *>>,
     val artemisRenames: Map<String, ImportClass<*>>,
+    val customExporters: Map<Var<ExportModel, Any>, (UserModel, ExportOptions) -> Any?> = emptyMap()
 ) {
     abstract fun createEmpty(): ExportModel
     abstract val userDataRepo: GenericUserDataRepo<UserModel>
@@ -72,12 +77,19 @@ abstract class ImportController<ExportModel: IExportClass<UserModel>, UserModel:
     val listRepos = exportRepos.filter { it.key returns List::class }
     val singleRepos = exportRepos.filter { !(it.key returns List::class) }
 
-    fun export(u: AquaNetUser) = createEmpty().apply {
+    fun export(u: AquaNetUser): ExportModel = export(u, ExportOptions())
+
+    fun export(u: AquaNetUser, options: ExportOptions) = createEmpty().apply {
         gameId = game
         userData = userDataRepo.findByCard(u.ghostCard) ?: (404 - "User not found")
         exportRepos.forEach { (f, u) ->
-            if (f returns List::class) f.set(this, u.findByUser(userData))
-            else u.findSingleByUser(userData)()?.let { f.set(this, it) }
+            val customExporter = customExporters[f]
+            if (customExporter != null) {
+                customExporter(userData, options)?.let { f.set(this, it) }
+            } else {
+                if (f returns List::class) f.set(this, u.findByUser(userData))
+                else u.findSingleByUser(userData)()?.let { f.set(this, it) }
+            }
         }
     }
 

--- a/src/main/java/icu/samnyan/aqua/net/games/ImportController.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/ImportController.kt
@@ -84,13 +84,11 @@ abstract class ImportController<ExportModel: IExportClass<UserModel>, UserModel:
         gameId = game
         userData = userDataRepo.findByCard(u.ghostCard) ?: (404 - "User not found")
         exportRepos.forEach { (f, u) ->
-            val customExporter = customExporters[f]
-            if (customExporter != null) {
-                customExporter(userData, options)?.let { f.set(this, it) }
-            } else {
-                if (f returns List::class) f.set(this, u.findByUser(userData))
-                else u.findSingleByUser(userData)()?.let { f.set(this, it) }
-            }
+            if (f returns List::class) f.set(this, u.findByUser(userData))
+            else u.findSingleByUser(userData)()?.let { f.set(this, it) }
+        }
+        customExporters.forEach { (f, exporter) ->
+            exporter(userData, options)?.let { f.set(this, it) }
         }
     }
 
@@ -106,8 +104,9 @@ abstract class ImportController<ExportModel: IExportClass<UserModel>, UserModel:
         val export = json.parseJackson(exportClass.java)
         if (!export.gameId.equals(game, true)) 400 - "Invalid game ID"
 
-        val lists = listRepos.toList().filter { (f, _) -> f !in customImporters }.associate { (f, r) -> r to f.get(export) as List<IUserEntity<UserModel>> }.vNotNull()
-        val singles = singleRepos.toList().filter { (f, _) -> f !in customImporters }.associate { (f, r) -> r to f.get(export) as IUserEntity<UserModel> }.vNotNull()
+        val lists = listRepos.toList().associate { (f, r) -> r to f.get(export) as List<IUserEntity<UserModel>> }.vNotNull()
+        val singles = singleRepos.toList().associate { (f, r) -> r to f.get(export) as IUserEntity<UserModel> }.vNotNull()
+        var repoFieldMap = exportRepos.toList().associate { (f, r) -> r to f }
 
         // Validate new user data
         // Check that all ids are 0 (this should be true since all ids are @JsonIgnore)

--- a/src/main/java/icu/samnyan/aqua/net/games/mai2/Mai2Import.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/mai2/Mai2Import.kt
@@ -112,5 +112,10 @@ data class Maimai2DataExport(
     var userFavoriteMusicList: List<Mai2UserFavoriteItem> = mutableListOf(),
     var userKaleidxScopeList: List<Mai2UserKaleidx> = mutableListOf(),
     var userPlaylogList: List<Mai2UserPlaylog> = mutableListOf(),
+    // Not supported yet:
+    // var userWeeklyData
+    // var userMissionDataList
+    // var userShopStockList
+    // var userTradeItemList
     override var gameId: String = "SDEZ",
 ): IExportClass<Mai2UserDetail>

--- a/src/main/java/icu/samnyan/aqua/net/games/mai2/Mai2Import.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/mai2/Mai2Import.kt
@@ -24,7 +24,7 @@ class Mai2Import(
         it.name.replace("List", "").lowercase()
     },
     exportRepos = Maimai2DataExport::class.vars()
-        .filter { f -> f.name !in setOf("gameId", "userData") }
+        .filter { f -> f.name !in setOf("gameId", "userData", "userPlaylogList", "userFavoriteMusicList") }
         .associateWith { field ->
             val repoName = when (field.name) {
                 "userKaleidxScopeList" -> "userKaleidx"
@@ -70,14 +70,18 @@ class Mai2Import(
         }
     ) as Map<kotlin.reflect.KMutableProperty1<Maimai2DataExport, Any>, (Mai2UserDetail, ExportOptions) -> Any?>,
     customImporters = mapOf(
+        Maimai2DataExport::userPlaylogList to { export: Maimai2DataExport, user: Mai2UserDetail ->
+            repos.userPlaylog.saveAll(export.userPlaylogList.map { it.apply { it.user = user } })
+        },
         Maimai2DataExport::userFavoriteMusicList to { export: Maimai2DataExport, user: Mai2UserDetail ->
             val favoriteMusicList = export.userFavoriteMusicList
             if (favoriteMusicList.isNotEmpty()) {
                 val key = "favorite_music"
+                // This field always imports as incremental, since the userGeneralData field (for backwards compatibility) is processed before this
                 val data = repos.userGeneralData.findByUserAndPropertyKey(user, key).orElse(null)
                     ?: Mai2UserGeneralData().apply { this.user = user; propertyKey = key }
                 repos.userGeneralData.save(data.apply {
-                    propertyValue = favoriteMusicList.map { it.id }.joinToString(",")
+                    propertyValue = favoriteMusicList.sortedBy { it.orderId }.map { it.id }.joinToString(",")
                 })
             }
         }
@@ -88,30 +92,25 @@ class Mai2Import(
 }
 
 data class Maimai2DataExport(
-    override var userData: Mai2UserDetail,
-    var userExtend: Mai2UserExtend,
-    var userOption: Mai2UserOption,
-    var userUdemae: Mai2UserUdemae,
-    var mapEncountNpcList: List<Mai2MapEncountNpc>,
-    var userActList: List<Mai2UserAct>,
-    var userCharacterList: List<Mai2UserCharacter>,
-    var userChargeList: List<Mai2UserCharge>,
-    var userCourseList: List<Mai2UserCourse>,
-    var userFavoriteList: List<Mai2UserFavorite>,
-    var userFriendSeasonRankingList: List<Mai2UserFriendSeasonRanking>,
-    var userGeneralDataList: List<Mai2UserGeneralData>,
-    var userItemList: List<Mai2UserItem>,
-    var userLoginBonusList: List<Mai2UserLoginBonus>,
-    var userMapList: List<Mai2UserMap>,
-    var userMusicDetailList: List<Mai2UserMusicDetail>,
-    var userIntimateList: List<Mai2UserIntimate>,
-    var userFavoriteMusicList: List<Mai2UserFavoriteItem>,
-    var userKaleidxScopeList: List<Mai2UserKaleidx>,
-    var userPlaylogList: List<Mai2UserPlaylog>,
+    override var userData: Mai2UserDetail = Mai2UserDetail(),
+    var userExtend: Mai2UserExtend = Mai2UserExtend(),
+    var userOption: Mai2UserOption = Mai2UserOption(),
+    var userUdemae: Mai2UserUdemae = Mai2UserUdemae(),
+    var mapEncountNpcList: List<Mai2MapEncountNpc> = mutableListOf(),
+    var userActList: List<Mai2UserAct> = mutableListOf(),
+    var userCharacterList: List<Mai2UserCharacter> = mutableListOf(),
+    var userChargeList: List<Mai2UserCharge> = mutableListOf(),
+    var userCourseList: List<Mai2UserCourse> = mutableListOf(),
+    var userFavoriteList: List<Mai2UserFavorite> = mutableListOf(),
+    var userFriendSeasonRankingList: List<Mai2UserFriendSeasonRanking> = mutableListOf(),
+    var userGeneralDataList: List<Mai2UserGeneralData> = mutableListOf(),
+    var userItemList: List<Mai2UserItem> = mutableListOf(),
+    var userLoginBonusList: List<Mai2UserLoginBonus> = mutableListOf(),
+    var userMapList: List<Mai2UserMap> = mutableListOf(),
+    var userMusicDetailList: List<Mai2UserMusicDetail> = mutableListOf(),
+    var userIntimateList: List<Mai2UserIntimate> = mutableListOf(),
+    var userFavoriteMusicList: List<Mai2UserFavoriteItem> = mutableListOf(),
+    var userKaleidxScopeList: List<Mai2UserKaleidx> = mutableListOf(),
+    var userPlaylogList: List<Mai2UserPlaylog> = mutableListOf(),
     override var gameId: String = "SDEZ",
-): IExportClass<Mai2UserDetail> {
-    constructor() : this(Mai2UserDetail(), Mai2UserExtend(), Mai2UserOption(), Mai2UserUdemae(),
-        mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf(),
-        mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf(),
-        mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf())
-}
+): IExportClass<Mai2UserDetail>

--- a/src/main/java/icu/samnyan/aqua/net/games/mai2/Mai2Import.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/mai2/Mai2Import.kt
@@ -9,6 +9,7 @@ import icu.samnyan.aqua.net.games.ImportClass
 import icu.samnyan.aqua.net.games.ImportController
 import icu.samnyan.aqua.sega.maimai2.model.Mai2Repos
 import icu.samnyan.aqua.sega.maimai2.model.Mai2UserLinked
+import icu.samnyan.aqua.sega.maimai2.model.request.Mai2UserFavoriteItem
 import icu.samnyan.aqua.sega.maimai2.model.userdata.*
 import org.springframework.web.bind.annotation.RestController
 import kotlin.reflect.full.declaredMembers
@@ -24,10 +25,15 @@ class Mai2Import(
     },
     exportRepos = Maimai2DataExport::class.vars()
         .filter { f -> f.name !in setOf("gameId", "userData") }
-        .associateWith { Mai2Repos::class.declaredMembers
-            .filter { f -> f returns Mai2UserLinked::class }
-            .firstOrNull { f -> f.name == it.name || f.name == it.name.replace("List", "") }
-            ?.call(repos) as Mai2UserLinked<*>? ?: error("No matching field found for ${it.name}")
+        .associateWith { field ->
+            val repoName = when (field.name) {
+                "userKaleidxScopeList" -> "userKaleidx"
+                else -> field.name.replace("List", "")
+            }
+            Mai2Repos::class.declaredMembers
+                .filter { f -> f returns Mai2UserLinked::class }
+                .firstOrNull { f -> f.name == repoName }
+                ?.call(repos) as Mai2UserLinked<*>? ?: error("No matching field found for ${field.name}")
         },
     artemisRenames = mapOf(
         "mai2_item_character" to ImportClass(Mai2UserCharacter::class),
@@ -46,17 +52,36 @@ class Mai2Import(
         "mai2_score_best" to ImportClass(Mai2UserMusicDetail::class),
         "mai2_score_course" to ImportClass(Mai2UserCourse::class),
     ),
-    customExporters = run {
-        mapOf(
-            Maimai2DataExport::userPlaylogList to { user: Mai2UserDetail, options: ExportOptions ->
-                if (options.playlogSince != null) {
-                    repos.userPlaylog.findByUserAndUserPlayDateAfter(user, options.playlogSince)
-                } else {
-                    repos.userPlaylog.findByUser(user)
-                }
+    customExporters = mapOf(
+        Maimai2DataExport::userPlaylogList to { user: Mai2UserDetail, options: ExportOptions ->
+            if (options.playlogSince != null) {
+                repos.userPlaylog.findByUserAndUserPlayDateAfter(user, options.playlogSince)
+            } else {
+                repos.userPlaylog.findByUser(user)
             }
-        ) as Map<kotlin.reflect.KMutableProperty1<Maimai2DataExport, Any>, (Mai2UserDetail, ExportOptions) -> Any?>
-    }
+        },
+        Maimai2DataExport::userFavoriteMusicList to { user: Mai2UserDetail, _: ExportOptions ->
+            repos.userGeneralData.findByUserAndPropertyKey(user, "favorite_music").orElse(null)
+                ?.propertyValue
+                ?.takeIf { it.isNotEmpty() }
+                ?.split(",")
+                ?.mapIndexed { index, id -> Mai2UserFavoriteItem().apply { orderId = index; this.id = id.toInt() } }
+                ?: emptyList()
+        }
+    ) as Map<kotlin.reflect.KMutableProperty1<Maimai2DataExport, Any>, (Mai2UserDetail, ExportOptions) -> Any?>,
+    customImporters = mapOf(
+        Maimai2DataExport::userFavoriteMusicList to { export: Maimai2DataExport, user: Mai2UserDetail ->
+            val favoriteMusicList = export.userFavoriteMusicList
+            if (favoriteMusicList.isNotEmpty()) {
+                val key = "favorite_music"
+                val data = repos.userGeneralData.findByUserAndPropertyKey(user, key).orElse(null)
+                    ?: Mai2UserGeneralData().apply { this.user = user; propertyKey = key }
+                repos.userGeneralData.save(data.apply {
+                    propertyValue = favoriteMusicList.map { it.id }.joinToString(",")
+                })
+            }
+        }
+    ) as Map<kotlin.reflect.KMutableProperty1<Maimai2DataExport, Any>, (Maimai2DataExport, Mai2UserDetail) -> Unit>
 ) {
     override fun createEmpty() = Maimai2DataExport()
     override val userDataRepo = repos.userData
@@ -79,11 +104,14 @@ data class Maimai2DataExport(
     var userLoginBonusList: List<Mai2UserLoginBonus>,
     var userMapList: List<Mai2UserMap>,
     var userMusicDetailList: List<Mai2UserMusicDetail>,
+    var userIntimateList: List<Mai2UserIntimate>,
+    var userFavoriteMusicList: List<Mai2UserFavoriteItem>,
+    var userKaleidxScopeList: List<Mai2UserKaleidx>,
     var userPlaylogList: List<Mai2UserPlaylog>,
     override var gameId: String = "SDEZ",
 ): IExportClass<Mai2UserDetail> {
     constructor() : this(Mai2UserDetail(), Mai2UserExtend(), Mai2UserOption(), Mai2UserUdemae(),
         mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf(),
         mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf(),
-        mutableListOf())
+        mutableListOf(), mutableListOf(), mutableListOf(), mutableListOf())
 }

--- a/src/main/java/icu/samnyan/aqua/net/games/mai2/Mai2Import.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/mai2/Mai2Import.kt
@@ -3,6 +3,7 @@ package icu.samnyan.aqua.net.games.mai2
 import ext.API
 import ext.returns
 import ext.vars
+import icu.samnyan.aqua.net.games.ExportOptions
 import icu.samnyan.aqua.net.games.IExportClass
 import icu.samnyan.aqua.net.games.ImportClass
 import icu.samnyan.aqua.net.games.ImportController
@@ -44,7 +45,18 @@ class Mai2Import(
         "mai2_profile_option" to ImportClass(Mai2UserOption::class, mapOf("version" to null)),
         "mai2_score_best" to ImportClass(Mai2UserMusicDetail::class),
         "mai2_score_course" to ImportClass(Mai2UserCourse::class),
-    )
+    ),
+    customExporters = run {
+        mapOf(
+            Maimai2DataExport::userPlaylogList to { user: Mai2UserDetail, options: ExportOptions ->
+                if (options.playlogSince != null) {
+                    repos.userPlaylog.findByUserAndUserPlayDateAfter(user, options.playlogSince)
+                } else {
+                    repos.userPlaylog.findByUser(user)
+                }
+            }
+        ) as Map<kotlin.reflect.KMutableProperty1<Maimai2DataExport, Any>, (Mai2UserDetail, ExportOptions) -> Any?>
+    }
 ) {
     override fun createEmpty() = Maimai2DataExport()
     override val userDataRepo = repos.userData

--- a/src/main/java/icu/samnyan/aqua/sega/maimai2/model/Repos.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/maimai2/model/Repos.kt
@@ -104,6 +104,7 @@ interface Mai2UserPlaylogRepo : GenericPlaylogRepo<Mai2UserPlaylog>, Mai2UserLin
         musicId: Int,
         userPlayDate: String
     ): MutableList<Mai2UserPlaylog>
+    fun findByUserAndUserPlayDateAfter(user: Mai2UserDetail, userPlayDate: String): List<Mai2UserPlaylog>
 }
 
 interface Mai2UserPrintDetailRepo : JpaRepository<Mai2UserPrintDetail, Long>


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

实现缺失的 Mai2 导出字段，通过扩展导出模型、更新映射逻辑，并添加带有 ExportOptions 的可自定义导入/导出钩子。

新特性：
- 添加 ExportOptions 和 customExporters/customImporters 到 ImportController，以启用特定字段的导入/导出逻辑

增强功能：
- 扩展 Maimai2DataExport，添加默认初始化器，并为 userIntimateList、userFavoriteMusicList 和 userKaleidxScopeList 添加字段
- 更新 Mai2Import，以包含缺失的导出字段，并处理 userKaleidxScopeList 的重命名逻辑
- 添加存储库方法 findByUserAndUserPlayDateAfter，以支持按日期过滤游戏记录

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement missing Mai2 export fields by extending the export model, updating mapping logic, and adding customizable import/export hooks with ExportOptions

New Features:
- Add ExportOptions and customExporters/customImporters to ImportController to enable field-specific import/export logic

Enhancements:
- Extend Maimai2DataExport with default initializers and added fields for userIntimateList, userFavoriteMusicList, and userKaleidxScopeList
- Update Mai2Import to include missing export fields and handle renaming logic for userKaleidxScopeList
- Add repository method findByUserAndUserPlayDateAfter to support filtering playlogs by date

</details>