### PR TITLE
[F] LocalDateTime format for Mai2 UserKaleidxScope

### DIFF
--- a/src/main/java/icu/samnyan/aqua/sega/maimai2/model/userdata/UserEntities.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/maimai2/model/userdata/UserEntities.kt
@@ -16,6 +16,11 @@ import lombok.AllArgsConstructor
 import lombok.Data
 import lombok.NoArgsConstructor
 import java.time.LocalDateTime
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import java.time.format.DateTimeFormatter
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.core.JsonGenerator
 
 @MappedSuperclass
 open class Mai2UserEntity : BaseEntity(), IUserEntity<Mai2UserDetail> {
@@ -526,10 +531,14 @@ class Mai2UserKaleidx : Mai2UserEntity() {
     var totalDeluxscore = 0
     var bestAchievement = 0
     var bestDeluxscore = 0
+    @JsonSerialize(using = MaimaiDateSerializer::class)
     var bestAchievementDate: LocalDateTime? = null
+    @JsonSerialize(using = MaimaiDateSerializer::class)
     var bestDeluxscoreDate: LocalDateTime? = null
     var playCount = 0
+    @JsonSerialize(using = MaimaiDateSerializer::class)
     var clearDate: LocalDateTime? = null
+    @JsonSerialize(using = MaimaiDateSerializer::class)
     var lastPlayDate: LocalDateTime? = null
     var isInfoWatched = false
 }
@@ -540,4 +549,11 @@ class Mai2UserIntimate : Mai2UserEntity() {
     var partnerId = 1;
     var intimateLevel = 0;
     var intimateCountRewarded = 0;
+}
+
+val MAIMAI_DATETIME = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.0")
+class MaimaiDateSerializer : JsonSerializer<LocalDateTime>() {
+    override fun serialize(v: LocalDateTime, j: JsonGenerator, s: SerializerProvider) {
+        j.writeString(v.format(MAIMAI_DATETIME))
+    }
 }


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

统一 Mai2UserKaleidx JSON 输出中 LocalDateTime 属性的格式，使用统一的模式 (yyyy-MM-dd HH:mm:ss.0)，以保持一致性。

增强功能：
- 引入自定义 JSON 序列化器 (MaimaiDateSerializer) 用于 Mai2UserKaleidx 中的 LocalDateTime 字段
- 使用 MaimaiDateSerializer 通过 JsonSerialize 注解 bestAchievementDate、bestDeluxscoreDate、clearDate 和 lastPlayDate

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Format LocalDateTime properties in Mai2UserKaleidx JSON output using a unified pattern (yyyy-MM-dd HH:mm:ss.0) for consistency.

Enhancements:
- Introduce custom JSON serializer (MaimaiDateSerializer) for LocalDateTime fields in Mai2UserKaleidx
- Annotate bestAchievementDate, bestDeluxscoreDate, clearDate, and lastPlayDate with JsonSerialize using MaimaiDateSerializer

</details>