### PR TITLE
feature: Batch-Manual export for CHUNITHM

### DIFF
--- a/AquaNet/src/components/settings/ChuniSettings.svelte
+++ b/AquaNet/src/components/settings/ChuniSettings.svelte
@@ -156,24 +156,27 @@
         let noteLamp = null;
 
         if (level in DIFFICULTY_MAP) {
-          if (CATASTROPHY_SKILL_IDS.includes(score.skillId)) {
-            clearLamp = "CATASTROPHY"
-          }
-          else if (ABSOLUTE_SKILL_IDS.includes(score.skillId)) {
-            clearLamp = "ABSOLUTE"
-          }
-          else if (BRAVE_SKILL_IDS.includes(score.skillId)) {
-            clearLamp = "BRAVE"
-          }
-          else if (HARD_SKILL_IDS.includes(score.skillId)) {
-            clearLamp = "HARD"
-          }
-          else if (score.isClear) {
-            clearLamp = "CLEAR"
+          if (score.isClear) {
+            if (CATASTROPHY_SKILL_IDS.includes(score.skillId)) {
+              clearLamp = "CATASTROPHY";
+            }
+            else if (ABSOLUTE_SKILL_IDS.includes(score.skillId)) {
+              clearLamp = "ABSOLUTE";
+            }
+            else if (BRAVE_SKILL_IDS.includes(score.skillId)) {
+              clearLamp = "BRAVE";
+            }
+            else if (HARD_SKILL_IDS.includes(score.skillId)) {
+              clearLamp = "HARD";
+            }
+            else {
+              clearLamp = "CLEAR";
+            }
           }
           else {
-            clearLamp = "FAILED"
+            clearLamp = "FAILED";
           }
+
           
           if (score.isAllPerfect) {
             noteLamp = "ALL JUSTICE CRITICAL"
@@ -198,7 +201,7 @@
               "attack": score.judgeAttack,
               "miss": score.judgeGuilty
             },
-            "matchType": "inGameId",
+            "matchType": "inGameID",
             "identifier": score.musicId.toString(),
             "difficulty": DIFFICULTY_MAP[level],
             "timeAchieved": new Date(score.userPlayDate).getTime(),

--- a/AquaNet/src/components/settings/ChuniSettings.svelte
+++ b/AquaNet/src/components/settings/ChuniSettings.svelte
@@ -106,6 +106,122 @@
       .finally(() => submitting = "")
   }
 
+  async function exportBatchManual() {
+    submitting = "batchExport"
+
+    const DIFFICULTY_MAP: Record<number, string> = {
+      0: "BASIC",
+      1: "ADVANCED",
+      2: "EXPERT",
+      3: "MASTER",
+      4: "ULTIMA"
+    } // WORLD'S END scores not supported by Tachi
+    const DAN_MAP: Record<number, string> = {
+      1: "DAN_I",
+      2: "DAN_II",
+      3: "DAN_III",
+      4: "DAN_IV",
+      5: "DAN_V",
+      6: "DAN_INFINITE"
+    }
+    const CATASTROPHY_SKILL_IDS: number[] = [100009, 102009, 103007]
+    const ABSOLUTE_SKILL_IDS: number[] = [100008, 101008, 102008, 103006]
+    const BRAVE_SKILL_IDS: number[] = [100007, 101007, 102007, 103005] // Needs to be updated every major version :(
+    const HARD_SKILL_IDS: number[] = [100005, 100006, 101004, 101005, 101006, 102004, 102005, 102006, 103002, 103003, 103004] // Shamelessly stolen from https://github.com/beer-psi/saekawa/commit/b3bee13e126df2f4e2a449bdf971debb8c95ba40
+
+    let data: any
+    let output: any = {
+      "meta": {
+        "game": "chunithm",
+        "playtype": "Single",
+        "service": "AquaDX-Manual"
+      },
+      "scores": [],
+      "classes": {}
+    }
+    
+    try {
+      data = await GAME.export('chu3');
+    }
+    catch (e) {
+      error = e.message;
+      submitting = ""
+      return;
+    }
+
+    if (data && "userPlaylogList" in data) {
+      for (let score of data.userPlaylogList) {
+        let level = score.level
+        let clearLamp = null;
+        let noteLamp = null;
+
+        if (level in DIFFICULTY_MAP) {
+          if (CATASTROPHY_SKILL_IDS.includes(score.skillId)) {
+            clearLamp = "CATASTROPHY"
+          }
+          else if (ABSOLUTE_SKILL_IDS.includes(score.skillId)) {
+            clearLamp = "ABSOLUTE"
+          }
+          else if (BRAVE_SKILL_IDS.includes(score.skillId)) {
+            clearLamp = "BRAVE"
+          }
+          else if (HARD_SKILL_IDS.includes(score.skillId)) {
+            clearLamp = "HARD"
+          }
+          else if (score.isClear) {
+            clearLamp = "CLEAR"
+          }
+          else {
+            clearLamp = "FAILED"
+          }
+          
+          if (score.isAllPerfect) {
+            noteLamp = "ALL JUSTICE CRITICAL"
+          }
+          else if (score.isAllJustice) {
+            noteLamp = "ALL JUSTICE"
+          }
+          else if (score.isFullCombo) {
+            noteLamp = "FULL COMBO"
+          }
+          else {
+            noteLamp = "NONE"
+          }
+
+          output.scores.push({
+            "score": score.score,
+            "clearLamp": clearLamp,
+            "noteLamp": noteLamp,
+            "judgements": {
+              "jcrit": score.judgeHeaven + score.judgeCritical,
+              "justice": score.judgeJustice,
+              "attack": score.judgeAttack,
+              "miss": score.judgeGuilty
+            },
+            "matchType": "inGameId",
+            "identifier": score.musicId.toString(),
+            "difficulty": DIFFICULTY_MAP[level],
+            "timeAchieved": new Date(score.userPlayDate).getTime(),
+            "optional": {
+              "maxCombo": score.maxCombo
+            }
+          })
+        }
+      }
+    }
+    
+    if (data.userData.classEmblemMedal in DAN_MAP) {
+      output.classes["dan"] = DAN_MAP[data.userData.classEmblemMedal]
+    }
+
+    if (data.userData.classEmblemBase in DAN_MAP) {
+      output.classes["emblem"] = DAN_MAP[data.userData.classEmblemBase]
+    }
+
+    download(JSON.stringify(output), `AquaDX_chu3_BatchManualExport_${userbox.userName}.json`)
+    submitting = ""
+  }
+
   function download(data: string, filename: string) {
     const blob = new Blob([data]);
     const url = URL.createObjectURL(blob);
@@ -300,6 +416,10 @@
   <button class="exportButton" on:click={exportData}>
     <Icon icon="bxs:file-export"/>
     {t('settings.export')}
+  </button>
+  <button class="exportBatchManualButton" on:click={exportBatchManual}>
+    <Icon icon="bxs:file-export"/>
+    {t('settings.batchManualExport')}
   </button>
 </div>
 {/if}

--- a/AquaNet/src/libs/i18n/en_ref.ts
+++ b/AquaNet/src/libs/i18n/en_ref.ts
@@ -183,6 +183,7 @@ export const EN_REF_SETTINGS = {
   'settings.profile.logout': 'Log out',
   'settings.profile.unchanged': 'Unchanged',
   'settings.export': 'Export Player Data',
+  'settings.batchManualExport': "Export in Batch Manual (for Tachi)",
   'settings.cabNotice': "Note: These settings will only affect your own cab/setup. If you're playing on someone else's setup, please contact them to change these settings.",
   'settings.gameNotice': "These only apply to Mai and Wacca."
 }

--- a/AquaNet/src/libs/i18n/zh.ts
+++ b/AquaNet/src/libs/i18n/zh.ts
@@ -195,6 +195,7 @@ const zhSettings: typeof EN_REF_SETTINGS = {
   'settings.profile.logout': '登出',
   'settings.profile.unchanged': '未更改',
   'settings.export': '导出玩家数据',
+  'settings.batchManualExport': "导出 Batch Manual 格式（用于 Tachi）",
   'settings.cabNotice': '注意：下面这些设置只会影响你自己的机器，如果你是在其他人的机器上玩的话，请联系机主来改设置',
   'settings.gameNotice': "这些设置仅对舞萌和华卡生效。",
 }


### PR DESCRIPTION
adds a button to the Chuni settings page to export data in Kamaitachi's [Batch-Manual](https://docs.tachi.ac/codebase/batch-manual/) format.

notes for maintenance:
- clear lamp skill ids need to be updated with major version / skill changes
- changes to `GAME.export('chu3')` schema may be breaking (unlikely)
- `GAME.export('chu3')` should have proper error handling but is untested

## Sourcery 摘要

在设置页面中为 CHUNITHM 提供一个新的批量手动导出选项，引入用户界面控件和导出逻辑以生成 Tachi 兼容的 JSON 文件。

新功能：
- 在 Chuni 设置中添加批量手动导出按钮和处理程序，以生成 Tachi 的批量手动 JSON 格式的 CHUNITHM 游玩数据

增强功能：
- 为批量手动导出按钮添加 i18n 条目，包括英文和中文

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide a new Batch-Manual export option for CHUNITHM in the settings page, introducing UI controls and export logic to produce Tachi-compatible JSON files.

New Features:
- Add Batch-Manual export button and handler in Chuni settings to generate CHUNITHM play data in Tachi’s Batch-Manual JSON format

Enhancements:
- Add i18n entries for the Batch Manual export button in English and Chinese

</details>