### PR TITLE
[+]: Package thin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -171,3 +171,21 @@ sourceSets {
         java.srcDir("${layout.buildDirectory.get()}/generated/source/kapt/main")
     }
 }
+
+val copyDependencies by tasks.registering(Copy::class) {
+    from(configurations.runtimeClasspath)
+    into("${layout.buildDirectory.get()}/libs/lib")
+}
+
+val packageThin by tasks.registering(Jar::class) {
+    group = "build"
+    from(sourceSets.main.get().output)
+    manifest {
+        attributes(
+            "Main-Class" to "icu.samnyan.aqua.EntryKt",
+            "Class-Path" to configurations.runtimeClasspath.get().files.joinToString(" ") { "lib/${it.name}" }
+        )
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    dependsOn(copyDependencies)
+}


### PR DESCRIPTION
只确保能跑，不确保能好好跑（

<img width="651" height="296" alt="1{P}~VD%3SI@GH4B ZUH3}E" src="https://github.com/user-attachments/assets/13a340ec-286e-40b5-a988-0e3dbbd51d44" />

## Sourcery 摘要

添加 Gradle 任务，通过单独复制运行时依赖并配置清单文件中的类路径，以生成一个瘦 JAR 包。

构建:
- 添加 'copyDependencies' 任务，将运行时类路径 JAR 包复制到 build/libs/lib 目录下
- 添加 'packageThin' Jar 任务，将应用程序组装成一个瘦 JAR 包，该 JAR 包带有一个引用外部库的 Class-Path 清单文件

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Gradle tasks to produce a thin JAR by copying runtime dependencies separately and configuring the manifest class-path

Build:
- Add 'copyDependencies' task to copy runtime classpath JARs into build/libs/lib
- Add 'packageThin' Jar task to assemble the application into a thin JAR with a Class-Path manifest referencing the external libs

</details>