### PR TITLE
Session Token Revitalization

### DIFF
--- a/src/main/java/icu/samnyan/aqua/net/components/JWT.kt
+++ b/src/main/java/icu/samnyan/aqua/net/components/JWT.kt
@@ -6,6 +6,7 @@ import icu.samnyan.aqua.net.db.AquaNetUser
 import icu.samnyan.aqua.net.db.AquaNetUserRepo
 import icu.samnyan.aqua.net.db.SessionToken
 import icu.samnyan.aqua.net.db.SessionTokenRepo
+import icu.samnyan.aqua.net.db.getTokenExpiry
 import io.jsonwebtoken.JwtParser
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
@@ -96,6 +97,10 @@ class JWT(
                     sessionRepo.delete(token)
                     return null
                 }
+
+                sessionRepo.save(token.apply{
+                    expiry = getTokenExpiry()
+                })
             }
 
             return token?.aquaNetUser

--- a/src/main/java/icu/samnyan/aqua/net/components/JWT.kt
+++ b/src/main/java/icu/samnyan/aqua/net/components/JWT.kt
@@ -63,7 +63,7 @@ class JWT(
     @Transactional
     fun gen(user: AquaNetUser): Str {
         val activeTokens = sessionRepo.findByAquaNetUserAuId(user.auId)
-            .sortedByDescending { it.expiry }.drop(4) // the cap is 5, but we append a new token after the fact
+            .sortedByDescending { it.expiry }.drop(9) // the cap is 10, but we append a new token after the fact
         if (activeTokens.isNotEmpty()) {
             sessionRepo.deleteAll(activeTokens)
         }

--- a/src/main/java/icu/samnyan/aqua/net/db/AquaNetSession.kt
+++ b/src/main/java/icu/samnyan/aqua/net/db/AquaNetSession.kt
@@ -7,6 +7,8 @@ import java.io.Serializable
 import java.time.Instant
 import java.util.UUID
 
+fun getTokenExpiry() = Instant.now().plusSeconds(7 * 86400)
+
 @Entity
 @Table(name = "aqua_net_session")
 class SessionToken(
@@ -16,7 +18,7 @@ class SessionToken(
 
     // Token creation time
     @Column(nullable = false)
-    var expiry: Instant = Instant.now().plusSeconds(14 * 86400),
+    var expiry: Instant = getTokenExpiry(),
 
     // Linking to the AquaNetUser
     @ManyToOne


### PR DESCRIPTION
I made a mistake with the original code and tokens would expire exactly 3 days after they were created with no way to revitalize. This fixes that, using the site will revitalize the token automatically.

## Sourcery 总结

修改会话令牌生命周期，使其在使用时自动重置过期时间，集中过期逻辑，将默认过期时间更改为 7 天，并将每用户的活跃令牌限制提高到 10 个。

错误修复：
- 每次使用时自动刷新会话令牌过期时间，以防止过早过期。

增强：
- 在一个共享的 `getTokenExpiry` 函数中集中令牌过期计算。
- 将默认令牌过期持续时间设置为 7 天。
- 将每用户的最大并发会话令牌从 5 个增加到 10 个。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revise session token lifecycle to automatically reset expiry on use, centralize expiry logic, change default expiry to 7 days, and raise the active token limit to 10 per user

Bug Fixes:
- Automatically refresh session token expiry on each use to prevent premature expiration

Enhancements:
- Centralize token expiry calculation in a shared getTokenExpiry function
- Set default token expiry duration to 7 days
- Increase maximum concurrent session tokens per user from 5 to 10

</details>