### PR TITLE
Feat: Favorites (for all supported games)

### DIFF
--- a/AquaNet/src/libs/generalTypes.ts
+++ b/AquaNet/src/libs/generalTypes.ts
@@ -107,7 +107,8 @@ export interface GenericGameSummary {
   lastVersion: string
   ratingComposition: { [key: string]: any }
   recent: GenericGamePlaylog[]
-  rival?: boolean
+  rival?: boolean,
+  favorites?: number[]
 }
 
 export interface MusicMeta {

--- a/AquaNet/src/libs/i18n/en_ref.ts
+++ b/AquaNet/src/libs/i18n/en_ref.ts
@@ -28,6 +28,7 @@ export const EN_REF_USER = {
   'UserHome.RemoveRival': "Remove from Rival",
   'UserHome.InvalidGame': "Game ${game} is not supported on the web UI yet. We only support maimai, chunithm, wacca, and ongeki for now.",
   'UserHome.ShowMoreRecent': 'Show more',
+  'UserHome.FavoriteSongs': 'Favorite Songs'
 }
 
 export const EN_REF_Welcome = {

--- a/AquaNet/src/libs/i18n/zh.ts
+++ b/AquaNet/src/libs/i18n/zh.ts
@@ -40,6 +40,7 @@ const zhUser: typeof EN_REF_USER = {
   'UserHome.RemoveRival': "移除劲敌",
   'UserHome.InvalidGame': "游戏 ${game} 还不支持网页端查看。我们目前只支持舞萌、中二、华卡和音击。",
   'UserHome.ShowMoreRecent': "显示更多",
+  'UserHome.FavoriteSongs': "收藏歌曲"
 }
 
 const zhWelcome: typeof EN_REF_Welcome = {

--- a/AquaNet/src/pages/UserHome.svelte
+++ b/AquaNet/src/pages/UserHome.svelte
@@ -325,7 +325,6 @@
       <RatingComposition title="Recent 10" comp={d.user.ratingComposition.recent10} {allMusics} game={game != "auto" ? game : "mai2"} top={10}/>
     {/if}
 
-
     <div class="recent">
       <h2>{t('UserHome.RecentScores')}</h2>
       <div class="scores">
@@ -368,6 +367,22 @@
         {/if}
       </div>
     </div>
+
+    {#if d.user.favorites != null && d.user.favorites.length > 0}
+      <div class="favorites">
+        <h2>{t('UserHome.FavoriteSongs')}</h2>
+        <div class="scores">
+          {#each d.user.favorites as favoriteSongId, i}
+            <div class:alt={i % 2 === 0}>
+              <img src={`${DATA_HOST}/d/${game}/music/00${favoriteSongId.toString().padStart(6, '0').substring(2)}.png`} alt="" on:error={coverNotFound} />
+              <div class="info">
+                <div class="song-title">{allMusics[favoriteSongId.toString()].name ?? t("UserHome.UnknownSong")}</div>
+              </div>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
   {/if}
 
   <StatusOverlays {error} loading={!d || isLoading} />
@@ -554,8 +569,57 @@
           flex-direction: row
           justify-content: space-between
 
+  .favorites
+    .scores
+      display: flex
+      flex-wrap: wrap
+      flex-direction: row
+      gap: 20px
+
+      // Image and song info
+      > div
+        display: flex
+        align-items: center
+        width: calc(calc(100% / 3) - 20px) // what the fuck is going on anymore
+
+        img
+          width: 50px
+          height: 50px
+          border-radius: vars.$border-radius
+          object-fit: cover
+
+        // Song info and score
+        > div.info
+          flex: 1
+          display: flex
+          justify-content: space-between
+          overflow: hidden
+          flex-direction: column
+
+          .first-line
+            display: flex
+            flex-direction: row
+
+          // Limit song name to one line
+          .song-title
+            max-width: 100%
+            overflow: hidden
+            text-overflow: ellipsis
+            white-space: nowrap
+
+          // Make song score and rank not wrap
+          > div:last-child
+            white-space: nowrap
+
+          @media (max-width: vars.$w-mobile)
+            flex-direction: column
+            gap: 0
+
+            .rank-text
+              text-align: left
+
   // Recent Scores section
-  .recent
+  .recents,
     .scores
       display: flex
       flex-direction: column

--- a/AquaNet/src/pages/UserHome.svelte
+++ b/AquaNet/src/pages/UserHome.svelte
@@ -373,10 +373,10 @@
         <h2>{t('UserHome.FavoriteSongs')}</h2>
         <div class="scores">
           {#each d.user.favorites as favoriteSongId, i}
-            <div class:alt={i % 2 === 0}>
+            <div>
               <img src={`${DATA_HOST}/d/${game}/music/00${favoriteSongId.toString().padStart(6, '0').substring(2)}.png`} alt="" on:error={coverNotFound} />
               <div class="info">
-                <div class="song-title">{allMusics[favoriteSongId.toString()].name ?? t("UserHome.UnknownSong")}</div>
+                <div class="song-title">{allMusics[favoriteSongId.toString()] ? allMusics[favoriteSongId.toString()].name : t("UserHome.UnknownSong")}</div>
               </div>
             </div>
           {/each}
@@ -576,11 +576,16 @@
       flex-direction: row
       gap: 20px
 
+
       // Image and song info
       > div
         display: flex
         align-items: center
         width: calc(calc(100% / 3) - 20px) // what the fuck is going on anymore
+        gap: 20px
+        
+        background-color: rgba(white, 0.03)
+        border-radius: vars.$border-radius
 
         img
           width: 50px
@@ -619,7 +624,7 @@
               text-align: left
 
   // Recent Scores section
-  .recents,
+  .recent
     .scores
       display: flex
       flex-direction: column

--- a/src/main/java/icu/samnyan/aqua/net/games/GameApiController.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/GameApiController.kt
@@ -148,7 +148,7 @@ abstract class GameApiController<T : IUserData>(val name: String, userDataClass:
         userMusicRepo.findByUser_Card_ExtIdAndMusicIdIn(card.extId, musicList)
     }
 
-    fun genericUserSummary(card: Card, ratingComp: Map<String, String>, rival: Boolean? = null): GenericGameSummary {
+    fun genericUserSummary(card: Card, ratingComp: Map<String, String>, rival: Boolean? = null, favorites: List<Int>? = null): GenericGameSummary {
         // Summary values: total plays, player rating, server-wide ranking
         // number of each rank, max combo, number of full combo, number of all perfect
         val user = userDataRepo.findByCard(card) ?: (404 - "Game data not found")
@@ -199,7 +199,8 @@ abstract class GameApiController<T : IUserData>(val name: String, userDataClass:
             ratingComposition = ratingComp,
             recent = plays.sortedBy { it.userPlayDate.toString() }.takeLast(100).reversed(),
             lastPlayedHost = user.lastClientId?.let { us.userRepo.findByKeychip(it)?.username },
-            rival = rival
+            rival = rival,
+            favorites = favorites
         )
     }
 

--- a/src/main/java/icu/samnyan/aqua/net/games/Models.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/Models.kt
@@ -47,7 +47,8 @@ data class GenericGameSummary(
 
     val recent: List<IGenericGamePlaylog>,
 
-    val rival: Boolean?
+    val rival: Boolean?,
+    val favorites: List<Int>?
 )
 
 data class GenericRankingPlayer(

--- a/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
@@ -60,7 +60,9 @@ class Chusan(
             "new" to (extra["rating_new_list"] ?: ""),
         )
 
-        genericUserSummary(card, ratingComposition)
+        val misc = rp.userMisc.findByUser_Card_ExtId(card.extId).first()
+
+        genericUserSummary(card, ratingComposition, null, misc.favMusic)
     }
 
     /**

--- a/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
@@ -60,9 +60,9 @@ class Chusan(
             "new" to (extra["rating_new_list"] ?: ""),
         )
 
-        val misc = rp.userMisc.findByUser_Card_ExtId(card.extId).first()
+        val misc = rp.userMisc.findByUser_Card_ExtId(card.extId).firstOrNull()
 
-        genericUserSummary(card, ratingComposition, null, misc.favMusic)
+        genericUserSummary(card, ratingComposition, null, misc?.favMusic)
     }
 
     /**

--- a/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
@@ -66,7 +66,7 @@ class Maimai2(
             }
         }
 
-        genericUserSummary(card, ratingComposition, isMyRival)
+        genericUserSummary(card, ratingComposition, isMyRival, extra["favorite_music"]?.split(",")?.mapNotNull{it -> it.toIntOrNull()})
     }
 
     @API("user-rating")

--- a/src/main/java/icu/samnyan/aqua/net/games/wacca/Wacca.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/wacca/Wacca.kt
@@ -31,7 +31,10 @@ class Wacca(
 
     override suspend fun userSummary(@RP username: String, @RP token: String?) = us.cardByName(username) { card ->
         // TODO: Rating composition
-        genericUserSummary(card, mapOf())
+
+        val data = userDataRepo.findByCard_ExtId(card.extId)
+
+        genericUserSummary(card, mapOf(), null, if (data.isPresent) data.get().favoriteSongs else null)
     }
 
     override val shownRanks: List<Pair<Int, String>> = waccaScores.filter { it.first > 85 * 10000 }


### PR DESCRIPTION
All games except Ongeki have been given a "favorite songs" section located beneath the recents.

<img width="1088" height="607" alt="image" src="https://github.com/user-attachments/assets/81265a5d-19dd-475f-a49b-3946f069ebb6" />

It's a little finicky and I'm not sure how well it'll work with a lot of songs since I don't have enough favorites data to test. I also have only tested on Chu3, not for Mai2 or Wacca.

This PR is also missing the song selector functionality from the other favorite songs PR, but I may add it back in the future. For now it's read-only.

## Sourcery 总结

通过扩展后端 API 以返回收藏曲目 ID 并更新用户主页 UI 以渲染支持游戏的样式化只读收藏部分，引入新的收藏歌曲功能。

新功能：
- 在用户主页的最近分数下方显示只读的收藏歌曲部分
- 扩展 GenericGameSummary API 模型，使其在响应中包含收藏歌曲 ID 列表

增强：
- 在 Chu3、Maimai2 和 Wacca 控制器中实现从用户数据仓库检索收藏夹
- 在 UserHome.svelte 中为收藏列表添加前端渲染、样式和错误处理

文档：
- 为“Favorite Songs”标签添加英文和中文的 i18n 条目

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在用户主页新增一个版块来展示用户的收藏歌曲，并扩展游戏摘要 API，使其能返回所有支持游戏的收藏歌曲。

新功能：
- 在用户主页的 Recent Scores 下方，为支持的游戏新增一个只读的“收藏歌曲”版块。
- 扩展 `GenericGameSummary` API，使其包含一个收藏歌曲 ID 列表。

改进：
- 从 `Chu3`、`Maimai2` 和 `Wacca` 控制器中的用户数据检索收藏歌曲 ID。
- 更新 TypeScript `GenericGameSummary` 接口，使其包含新的 `favorites` 字段。
- 在 `UserHome.svelte` 中实现 Favorites 版块的前端渲染、样式和错误处理。

文档：
- 为“收藏歌曲”标签添加英文和中文的 i18n 条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Display users’ favorite songs in a new section on the user homepage and extend the game summary API to return favorites for all supported games

New Features:
- Add a read-only Favorite Songs section under Recent Scores on the user homepage for supported games
- Extend the GenericGameSummary API to include a favorites list of song IDs

Enhancements:
- Retrieve favorite song IDs from user data in Chu3, Maimai2, and Wacca controllers
- Update the TypeScript GenericGameSummary interface to include the new favorites field
- Implement front-end rendering, styling, and error handling for the Favorites section in UserHome.svelte

Documentation:
- Add English and Chinese i18n entries for the Favorite Songs label

</details>

</details>