### PR TITLE
[+] Add APIs

### DIFF
--- a/src/main/java/icu/samnyan/aqua/sega/maimai2/Maimai2Apis.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/maimai2/Maimai2Apis.kt
@@ -9,6 +9,7 @@ import icu.samnyan.aqua.sega.maimai2.model.UserRivalMusicDetail
 import icu.samnyan.aqua.sega.maimai2.model.userdata.Mai2UserKaleidx
 import icu.samnyan.aqua.sega.maimai2.model.userdata.UserRegions
 import java.time.LocalDate
+import kotlin.random.Random
 
 fun Maimai2ServletController.initApis() {
     val log = logger()
@@ -312,14 +313,6 @@ fun Maimai2ServletController.initApis() {
         )
     }
 
-    "GetServerAnnouncement" static { mapOf(
-        "title" to "",
-        "announcement" to "",
-        "showOnIdle" to false,
-        "showOnUserLogin" to false,
-        "imageUrl" to "",
-    ) }
-
     "GetGameWeeklyData" static { mapOf(
         "gameWeeklyData" to mapOf(
             "missionCategory" to 0,
@@ -362,4 +355,71 @@ fun Maimai2ServletController.initApis() {
             "userRecommendSelectionMusicIdList" to (net.recommendedMusic[user.id] ?: empty)
         )
     }
+
+    "GetGameFesta" { mapOf(
+        "eventId" to 0,
+        "isRallyPeriod" to false,
+        "isCircleJoinNotAllowed" to false,
+        "jackingFestaSideId" to Random.nextInt(0, 3),
+        "festaSideDataList" to empty,
+    ) }
+
+    "GetPlaceCircleData" static { mapOf(
+        "returnCode" to 0,
+        "circleId" to 0,
+        "aggrDate" to ""
+    ) }
+
+    "GetUserCircleData" static { mapOf(
+        "circleId" to 0,
+        "circleName" to "一緒に歌おう！",
+        "isPlace" to false,
+        "circleClass" to 0,
+        "lastLoginDate" to "",
+        "circlePointRankingList" to empty
+    ) }
+
+    "GetUserCirclePointData" { mapOf(
+        "userId" to uid,
+        "aggrDate" to "",
+        "userCirclePointDataList" to empty
+    ) }
+
+    "GetUserCirclePointRanking" static { mapOf(
+        "circleId" to 0,
+        "circleName" to "一緒に歌おう！",
+        "aggrDate" to "",
+        "lastMonthCircleRank" to 0,
+        "lastMonthPoint" to 0
+    ) }
+
+    "GetUserFesta" static { mapOf(
+        "userFestaData" to mapOf(
+            "eventId" to 0,
+            "circleId" to 0,
+            "festaSideId" to 0,
+            "circleTotalFestaPoint" to 0,
+            "currentTotalFestaPoint" to 0,
+            "circleRankInFestaSide" to 0,
+            "circleRecordDate" to "",
+            "isDailyBonus" to false,
+            "participationRewardGet" to false,
+            "receivedRewardBorder" to 0
+        ),
+        "userResultFestaData" to mapOf(
+            "eventId" to 0,
+            "circleId" to 0,
+            "circleName" to "一緒に歌おう！",
+            "festaSideId" to 0,
+            "circleRankInFestaSide" to 0,
+            "receivedRewardBorder" to 0,
+            "circleTotalFestaPoint" to 0,
+            "resultRewardGet" to false,
+        )
+    ) }
+
+    "UpsertUserPlaceCircleRegist" static { mapOf(
+        "returnCode" to 0,
+        "apiName" to "UpsertUserPlaceCircleRegistApi"
+    ) }
 }

--- a/src/main/java/icu/samnyan/aqua/sega/maimai2/Maimai2ServletController.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/maimai2/Maimai2ServletController.kt
@@ -55,7 +55,7 @@ class Maimai2ServletController(
     val endpointList = setOf("GetGameRankingApi","GetUserCharacterApi","GetUserItemApi","GetUserPortraitApi",
         "GetUserRatingApi","UploadUserPhotoApi","UploadUserPlaylogApi","UploadUserPortraitApi","UpsertUserAllApi",
         "CMGetUserCardApi","CMGetUserCardPrintErrorApi","CMGetUserDataApi","CMGetUserItemApi","CMUpsertUserPrintApi",
-        "GetUserFavoriteItemApi","GetServerAnnouncementApi")
+        "GetUserFavoriteItemApi")
 
     val noopEndpoint = setOf("GetUserScoreRankingApi", "UpsertClientBookkeepingApi",
         "UpsertClientSettingApi", "UpsertClientTestmodeApi", "UpsertClientUploadApi", "Ping", "RemoveTokenApi",


### PR DESCRIPTION
## Sourcery 总结

添加多个新的 Maimai2 API，用于处理圈子和 festa 数据，移除过时的服务器公告端点，并集成 kotlin.random 以生成 festa 侧标识符。

新功能：
- 引入 GetGameFesta API，提供事件和 festa 侧信息
- 添加 GetPlaceCircleData、GetUserCircleData、GetUserCirclePointData 和 GetUserCirclePointRanking API，用于圈子管理
- 添加 GetUserFesta API，返回用户 festa 参与和结果详情
- 添加 UpsertUserPlaceCircleRegist API，处理用户圈子注册更新

改进：
- 移除已弃用的 GetServerAnnouncement 端点

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为节日和圈子功能添加多个 Maimai2 API 存根，并移除废弃的服务器公告端点。

新功能：
- 引入 GetGameFesta API 存根，返回事件详情和随机的 jackingFestaSideId
- 添加 GetPlaceCircleData API 存根，用于检索圈子放置元数据
- 添加 GetUserCircleData API 存根，用于获取用户的圈子信息和排名
- 添加 GetUserCirclePointData API 存根，用于检索用户的圈子点数历史记录
- 添加 GetUserCirclePointRanking API 存根，用于获取上个月的圈子排名和点数
- 添加 GetUserFesta API 存根，用于用户节日参与和结果数据
- 添加 UpsertUserPlaceCircleRegist API 存根，用于用户圈子注册

改进：
- 导入 kotlin.random.Random 用于节日侧边随机化

杂项：
- 移除废弃的 GetServerAnnouncement 存根

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add multiple Maimai2 API stubs for festival and circle features and remove the obsolete server announcement endpoint

New Features:
- Introduce GetGameFesta API stub returning event details and random jackingFestaSideId
- Add GetPlaceCircleData API stub for retrieving circle placement metadata
- Add GetUserCircleData API stub for fetching user’s circle information and rankings
- Add GetUserCirclePointData API stub for retrieving user’s circle point history
- Add GetUserCirclePointRanking API stub for fetching last month’s circle ranking and points
- Add GetUserFesta API stub for user festival participation and result data
- Add UpsertUserPlaceCircleRegist API stub for user circle registration

Enhancements:
- Import kotlin.random.Random for festivity side randomization

Chores:
- Remove deprecated GetServerAnnouncement stub

</details>

</details>