### PR TITLE
fix: X-Verse Username

### DIFF
--- a/src/main/java/icu/samnyan/aqua/sega/chusan/handler/ChusanUpsertApis.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/chusan/handler/ChusanUpsertApis.kt
@@ -25,7 +25,14 @@ fun ChusanController.upsertApiInit() {
             val u = (userData?.get(0) ?: return@api null).apply {
                 id = oldUser?.id ?: 0
                 card = oldUser?.card ?: us.cardRepo.findByExtId(uid).expect("Card not found")
-                userName = userName.fromChusanUsername()
+
+                val version = data["version"] as? String ?: "0.00"
+                val versionNumber = version.toDoubleOrNull() ?: 0.0
+                userName = if (versionNumber >= 2.40) {
+                    userName
+                } else {
+                    userName.fromChusanUsername()
+                }
                 userNameEx = ""
             }.also { db.userData.saveAndFlush(it) }
 
@@ -92,10 +99,22 @@ fun ChusanController.upsertApiInit() {
                     score = it.score
                 }
 
-                selectUserName = selectUserName.fromChusanUsername()
-                opponentUserName1 = opponentUserName1.fromChusanUsername()
-                opponentUserName2 = opponentUserName2.fromChusanUsername()
-                opponentUserName3 = opponentUserName3.fromChusanUsername()
+                // 版本 >= 2.40 时不需要转换用户名编码，直接使用原始用户名
+                val version = data["version"] as? String ?: "0.00"
+                val versionNumber = version.toDoubleOrNull() ?: 0.0
+                if (versionNumber >= 2.40) {
+                    // 2.40及以上版本直接使用原始用户名
+                    selectUserName = selectUserName
+                    opponentUserName1 = opponentUserName1
+                    opponentUserName2 = opponentUserName2
+                    opponentUserName3 = opponentUserName3
+                } else {
+                    // 2.40以下版本需要转换编码
+                    selectUserName = selectUserName.fromChusanUsername()
+                    opponentUserName1 = opponentUserName1.fromChusanUsername()
+                    opponentUserName2 = opponentUserName2.fromChusanUsername()
+                    opponentUserName3 = opponentUserName3.fromChusanUsername()
+                }
             }) }
 
             // List data

--- a/src/main/java/icu/samnyan/aqua/sega/chusan/handler/ChusanUpsertApis.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/chusan/handler/ChusanUpsertApis.kt
@@ -99,16 +99,9 @@ fun ChusanController.upsertApiInit() {
                     score = it.score
                 }
 
-                // 版本 >= 2.40 时不需要转换用户名编码，直接使用原始用户名
                 val version = data["version"] as? String ?: "0.00"
                 val versionNumber = version.toDoubleOrNull() ?: 0.0
-                if (versionNumber >= 2.40) {
-                    // 2.40及以上版本直接使用原始用户名
-                    selectUserName = selectUserName
-                    opponentUserName1 = opponentUserName1
-                    opponentUserName2 = opponentUserName2
-                    opponentUserName3 = opponentUserName3
-                } else {
+                if (versionNumber < 2.40) {
                     // 2.40以下版本需要转换编码
                     selectUserName = selectUserName.fromChusanUsername()
                     opponentUserName1 = opponentUserName1.fromChusanUsername()


### PR DESCRIPTION
中二 XVerse 似乎修改了用户名的编码，导致打完 1PC 之后用户名变成 ？？？？
然后，还有一种修复方式是不允许覆盖现有的用户名，但是这样的话第一 PC 也会炸
所以现在是进行了版本号的对比。要是 ICF 什么的有问题的话，那就自求多福吧

## Sourcery 总结

Bug 修复:
- 仅对低于 2.40 的客户端版本应用 fromChusanUsername 转换，在新版本上保留原始用户名

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Only apply fromChusanUsername conversion for client versions below 2.40, preserving original usernames on newer versions

</details>