### PR TITLE
fix: mobile styling for favorites

### DIFF
--- a/AquaNet/src/pages/UserHome.svelte
+++ b/AquaNet/src/pages/UserHome.svelte
@@ -571,17 +571,14 @@
 
   .favorites
     .scores
-      display: flex
-      flex-wrap: wrap
-      flex-direction: row
+      display: grid
+      grid-template-columns: repeat(auto-fill, minmax(260px, 1fr))
       gap: 20px
-
 
       // Image and song info
       > div
         display: flex
         align-items: center
-        width: calc(calc(100% / 3) - 20px) // what the fuck is going on anymore
         gap: 20px
         
         background-color: rgba(white, 0.03)
@@ -607,7 +604,7 @@
 
           // Limit song name to one line
           .song-title
-            max-width: 100%
+            max-width: 90%
             overflow: hidden
             text-overflow: ellipsis
             white-space: nowrap


### PR DESCRIPTION
responsive # of columns for favorites section, makes it readable on smaller screen sizes and more consistent with the best scores display

## Sourcery 总结

通过切换到具有自动填充列的 CSS 网格并调整标题宽度，使收藏夹部分的布局在小屏幕上具有响应性

增强功能：
- 将收藏夹分数容器从弹性布局切换到具有自动填充列的响应式 CSS 网格
- 调整 `.song-title` 的最大宽度为 90%，以防止在窄屏幕上出现溢出

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the favorites section layout responsive on smaller screens by switching to a CSS grid with auto-fill columns and adjusting title width

Enhancements:
- Switch the favorites scores container from a flex layout to a responsive CSS grid with auto-fill columns
- Adjust the .song-title max-width to 90% to prevent overflow on narrow screens

</details>