### PR TITLE
refactor: user registrar

### DIFF
--- a/src/main/java/icu/samnyan/aqua/net/UserRegistrar.kt
+++ b/src/main/java/icu/samnyan/aqua/net/UserRegistrar.kt
@@ -34,7 +34,6 @@ class UserRegistrar(
     val cardService: CardService,
     val validator: AquaUserServices,
     val emailProps: EmailProperties,
-    val sessionRepo: SessionTokenRepo,
     final val paths: PathProps
 ) {
     val portraitPath = paths.aquaNetPortrait.path()
@@ -68,29 +67,7 @@ class UserRegistrar(
         val country = geoIP.getCountry(ip)
 
         // Create user
-        val u = async { AquaNetUser(
-            username = validator.checkUsername(username),
-            email = validator.checkEmail(email),
-            pwHash = validator.checkPwHash(password),
-            regTime = millis(), lastLogin = millis(), country = country,
-        ) }
-
-        // Create a ghost card
-        val card = Card().apply {
-            extId = cardService.randExtID(cardExtIdStart, cardExtIdEnd)
-            luid = extId.toString()
-            registerTime = LocalDateTime.now()
-            accessTime = registerTime
-            aquaUser = u
-            isGhost = true
-        }
-        u.ghostCard = card
-
-        // Save the user
-        async {
-            userRepo.save(u)
-            cardRepo.save(card)
-        }
+        val u = async { validator.create(username, email, password, country) }
 
         // Send confirmation email
         emailService.sendConfirmation(u)
@@ -205,11 +182,6 @@ class UserRegistrar(
         // Remove the token from the list
         resetPasswordRepo.delete(reset)
 
-        // Clear all sessions
-        sessionRepo.deleteAll(
-            sessionRepo.findByAquaNetUserAuId(reset.aquaNetUser.auId)
-        )
-
         return SUCCESS
     }
 
@@ -245,21 +217,14 @@ class UserRegistrar(
     @API("/setting")
     @Doc("Validate and set a user setting field.", "Success message")
     suspend fun setting(@RP token: Str, @RP key: Str, @RP value: Str) = jwt.auth(token) { u ->
-        // Check if the key is a settable field
-        val field = SETTING_FIELDS.find { it.name == key } ?: (400 - "Invalid setting")
-
         async {
-            // Set the validated field
-            field.setter.call(u, field.checker.call(validator, value))
+            validator.update(u, key, value)
 
             // Save the user
             userRepo.save(u)
 
             // Clear all tokens if changing password
-            if (key == "pwHash")
-                sessionRepo.deleteAll(
-                    sessionRepo.findByAquaNetUserAuId(u.auId)
-                )
+            if (key == "pwHash") validator.clearAllSessions(u)
         }
 
         SUCCESS

--- a/src/main/java/icu/samnyan/aqua/net/db/AquaNetUser.kt
+++ b/src/main/java/icu/samnyan/aqua/net/db/AquaNetUser.kt
@@ -2,6 +2,8 @@ package icu.samnyan.aqua.net.db
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import ext.*
+import icu.samnyan.aqua.net.UserRegistrar.Companion.cardExtIdEnd
+import icu.samnyan.aqua.net.UserRegistrar.Companion.cardExtIdStart
 import icu.samnyan.aqua.net.components.JWT
 import icu.samnyan.aqua.sega.allnet.AllNetProps
 import icu.samnyan.aqua.sega.allnet.KeyChipRepo
@@ -9,11 +11,13 @@ import icu.samnyan.aqua.sega.allnet.KeychipSession
 import icu.samnyan.aqua.sega.general.GameMusicPopularity
 import icu.samnyan.aqua.sega.general.dao.CardRepository
 import icu.samnyan.aqua.sega.general.model.Card
+import icu.samnyan.aqua.sega.general.service.CardService
 import jakarta.persistence.*
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import java.io.Serializable
+import java.time.LocalDateTime
 import kotlin.jvm.optionals.getOrNull
 import kotlin.reflect.KFunction
 import kotlin.reflect.KMutableProperty
@@ -124,7 +128,9 @@ class AquaUserServices(
     val allNetProps: AllNetProps,
     val jwt: JWT,
     val em: EntityManager,
-    val pop: GameMusicPopularity
+    val pop: GameMusicPopularity,
+    val cardService: CardService,
+    val sessionRepo: SessionTokenRepo,
 ) {
     companion object {
         val SETTING_FIELDS = AquaUserServices::class.functions
@@ -135,6 +141,42 @@ class AquaUserServices(
                 SettingField(name, it, prop.setter)
             }
     }
+
+    fun create(username: Str, email: Str, password: Str, country: Str): AquaNetUser {
+        // Create user
+        val u = AquaNetUser(
+            username = checkUsername(username),
+            email = validateEmail(email),
+            pwHash = checkPwHash(password),
+            regTime = millis(), lastLogin = millis(), country = country,
+        )
+
+        // Create a ghost card
+        val card = Card().apply {
+            extId = cardService.randExtID(cardExtIdStart, cardExtIdEnd)
+            luid = extId.toString()
+            registerTime = LocalDateTime.now()
+            accessTime = registerTime
+            aquaUser = u
+            isGhost = true
+        }
+        u.ghostCard = card
+
+        // Save the user
+        userRepo.save(u)
+        cardRepo.save(card)
+
+        return u
+    }
+
+    fun update(user: AquaNetUser, key: Str, value: Str) {
+        // Check if the key is a settable field
+        val field = SETTING_FIELDS.find { it.name == key } ?: (400 - "Invalid setting")
+        // Set the validated field
+        field.setter.call(user, field.checker.call(this, value))
+    }
+
+    fun clearAllSessions(user: AquaNetUser) = sessionRepo.deleteAll(sessionRepo.findByAquaNetUserAuId(user.auId))
 
     suspend fun <T> byName(username: Str, callback: suspend (AquaNetUser) -> T) =
         async { userRepo.findByUsernameIgnoreCase(username) }?.let { callback(it) } ?: (404 - "User not found")
@@ -173,7 +215,7 @@ class AquaUserServices(
             400 - "User with username `$this` already exists"
     }
 
-    fun checkEmail(email: Str) = email.apply {
+    fun validateEmail(email: Str) = email.apply {
         // Check if email is valid
         if (!isValidEmail()) 400 - "Invalid email"
 


### PR DESCRIPTION
## Sourcery 摘要

通过将创建、设置更新和会话管理逻辑移至 `AquaUserServices` 中，并从 `UserRegistrar` 进行委托，从而集中并简化用户注册流程。

增强：
- 在 `AquaUserServices` 中添加 `create` 方法，以处理用户和幽灵卡（ghost card）的创建。
- 在 `AquaUserServices` 中引入 `update` 和 `clearAllSessions` 方法，用于用户设置更新和会话管理。
- 将 `UserRegistrar` 中的用户创建、设置更新和会话清除委托给 `AquaUserServices`。
- 将 `AquaUserServices.checkEmail` 重命名为 `validateEmail` 并更新其引用。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将用户注册、设置管理和会话处理整合到 `AquaUserServices` 中，并重构 `UserRegistrar` 以委托给这些新的服务方法。

新功能：
- 添加 `AquaUserServices.create` 以处理用户注册和幽灵卡创建
- 添加 `AquaUserServices.update` 以验证和应用动态用户设置更改
- 添加 `AquaUserServices.clearAllSessions` 以移除用户的所有活动会话

改进：
- 重构 `UserRegistrar`，将用户创建和设置更新委托给 `AquaUserServices`
- 将 `checkEmail` 重命名为 `validateEmail`，以明确验证意图
- 将会话清除逻辑整合到服务层，并移除 `UserRegistrar` 中的重复代码

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Consolidate user registration, settings management, and session handling into AquaUserServices and refactor UserRegistrar to delegate to these new service methods.

New Features:
- Add AquaUserServices.create to handle user registration and ghost card creation
- Add AquaUserServices.update to validate and apply dynamic user setting changes
- Add AquaUserServices.clearAllSessions to remove all active sessions for a user

Enhancements:
- Refactor UserRegistrar to delegate user creation and settings updates to AquaUserServices
- Rename checkEmail to validateEmail for clearer validation intent
- Consolidate session clearing logic into the service layer and remove duplication in UserRegistrar

</details>

</details>