### PR TITLE
feat: crop pfp to at most 1024px

### DIFF
--- a/AquaNet/src/pages/User/Settings.svelte
+++ b/AquaNet/src/pages/User/Settings.svelte
@@ -80,11 +80,12 @@
     // Don't know why this isn't just a part of the cropper module. Have to do this myself.. What a shame
     let canvas = document.createElement("canvas");
     let ctx = canvas.getContext("2d");
-    canvas.width = 256;
-    canvas.height = 256;
+    const size = Math.round(Math.min(pfpCrop.width, pfpCrop.height, 1024));
+    canvas.width = size;
+    canvas.height = size;
     let img = document.createElement("img");
     img.onload = () => {
-      ctx?.drawImage(img, pfpCrop.x, pfpCrop.y, pfpCrop.width, pfpCrop.height, 0, 0, 256, 256);
+      ctx?.drawImage(img, pfpCrop.x, pfpCrop.y, pfpCrop.width, pfpCrop.height, 0, 0, size, size);
       canvas.toBlob(blob => {
         if (!blob) return;
         submitting = 'profilePicture'
@@ -282,7 +283,7 @@
       object-fit: cover
       aspect-ratio: 1
 
-      
+
 
   .cropper-container
     position: relative


### PR DESCRIPTION
## Sourcery 总结

新功能：
- 允许个人资料图片裁剪输出缩放到实际裁剪尺寸，上限为 1024px，而不是始终 256px。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Allow profile picture crop output to scale to the actual crop dimensions up to a 1024px cap instead of always 256px.

</details>