### PR TITLE
fix: total_point null

### DIFF
--- a/src/main/resources/db/80/V1000_60__fix_maimai2_point_nullability.sql
+++ b/src/main/resources/db/80/V1000_60__fix_maimai2_point_nullability.sql
@@ -1,0 +1,11 @@
+# Fix NULL values in maimai2_user_detail point and total_point fields
+# These fields were added without NOT NULL constraint in V1000_36
+
+# First, set NULL values to 0
+UPDATE maimai2_user_detail SET point = 0 WHERE point IS NULL;
+UPDATE maimai2_user_detail SET total_point = 0 WHERE total_point IS NULL;
+
+# Then add NOT NULL constraint
+ALTER TABLE maimai2_user_detail MODIFY point INT NOT NULL DEFAULT 0;
+ALTER TABLE maimai2_user_detail MODIFY total_point INT NOT NULL DEFAULT 0;
+


### PR DESCRIPTION
total_point 和 point 在代码里是不可为 null 的，但是在数据库里可空
然后，有人导入了没有这两个字段的数据，然后就爆了
甚至日志输出里面都没有能用于排错的有效信息

## Sourcery 摘要

通过将 `maimai2_user_detail` 表中 `point` 和 `total_point` 字段的现有 null 值迁移为零并更新 schema，强制执行非空约束。

增强:
- 添加 SQL 迁移，将现有的 `point` 和 `total_point` 的 NULL 值设置为 0
- 修改 `maimai2_user_detail` 表，使 `point` 和 `total_point` 列为 NOT NULL 且默认值为 0

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce non-null constraints on maimai2_user_detail point and total_point fields by migrating existing nulls to zero and updating the schema

Enhancements:
- Add SQL migration to set existing NULL point and total_point values to 0
- Alter maimai2_user_detail table to make point and total_point columns NOT NULL with default 0

</details>