### PR TITLE
[F] Player name validation

### DIFF
--- a/src/main/java/icu/samnyan/aqua/net/games/GameHelper.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/GameHelper.kt
@@ -11,7 +11,7 @@ const val LETTERS = "ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳ�
 const val SYMBOLS = "・：；？！～／＋－×÷＝♂♀∀＃＆＊＠☆○◎◇□△▽♪†‡ΣαβγθφψωДё＄（）．＿　"
 const val KANA = "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん" +
     "アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン"
-const val SEGA_USERNAME_CAHRS = LETTERS + SYMBOLS + KANA
+const val SEGA_USERNAME_CHARS = LETTERS + SYMBOLS + KANA
 const val WACCA_USERNAME_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
     "abcdefghijklmnopqrstuvwxyz" +
     "0123456789" +

--- a/src/main/java/icu/samnyan/aqua/net/games/GameHelper.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/GameHelper.kt
@@ -8,7 +8,7 @@ import java.time.LocalDate
 const val LETTERS = "ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ" +
     "ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ" +
     "０１２３４５６７８９"
-const val SYMBOLS = "・：；？！～／＋－×÷＝♂♀∀＃＆＊＠☆○◎◇□△▽♪†‡ΣαβγθφψωДё＄（）．＿␣"
+const val SYMBOLS = "・：；？！～／＋－×÷＝♂♀∀＃＆＊＠☆○◎◇□△▽♪†‡ΣαβγθφψωДё＄（）．＿　"
 const val KANA = "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん" +
     "アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン"
 const val SEGA_USERNAME_CAHRS = LETTERS + SYMBOLS + KANA

--- a/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
@@ -25,7 +25,7 @@ class Chusan(
     // Only show > AAA rank
     override val shownRanks = chu3Scores.filter { it.first >= 95 * 10000 }
     override val settableFields: Map<String, (Chu3UserData, String) -> Unit> by lazy { mapOf(
-        "userName" to usernameCheck(SEGA_USERNAME_CAHRS),
+        "userName" to usernameCheck(SEGA_USERNAME_CHARS),
         "nameplateId" to { u, v -> u.nameplateId = v.int },
         "frameId" to { u, v -> u.frameId = v.int },
         "trophyId" to { u, v -> u.trophyId = v.int },

--- a/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
@@ -29,7 +29,7 @@ class Maimai2(
     // Only show > S rank
     override val shownRanks = mai2Scores.filter { it.first >= 97 * 10000 }
     override val settableFields: Map<String, (Mai2UserDetail, String) -> Unit> by lazy { mapOf(
-        "userName" to usernameCheck(SEGA_USERNAME_CAHRS),
+        "userName" to usernameCheck(SEGA_USERNAME_CHARS),
         "iconId" to { u, v -> u.iconId = v.int() },
         "plateId" to { u, v -> u.plateId = v.int() },
         "titleId" to { u, v -> u.titleId = v.int() },

--- a/src/main/java/icu/samnyan/aqua/net/games/ongeki/Ongeki.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/ongeki/Ongeki.kt
@@ -27,7 +27,7 @@ class Ongeki(
 
     override val shownRanks = ongekiScores.filter { it.first >= 950000 }
     override val settableFields: Map<String, (UserData, String) -> Unit> by lazy { mapOf(
-        "userName" to usernameCheck(SEGA_USERNAME_CAHRS),
+        "userName" to usernameCheck(SEGA_USERNAME_CHARS),
 
         "lastRomVersion" to { u, v -> u.lastRomVersion = v },
         "lastDataVersion" to { u, v -> u.lastDataVersion = v },


### PR DESCRIPTION
## Sourcery 总结

修复 Sega 玩家名称验证，通过重命名用户名字符集常量并更新允许的符号列表以包含全角空格

改进：
- 将常量 `SEGA_USERNAME_CAHRS` 重命名为 `SEGA_USERNAME_CHARS`，以修正拼写错误
- 在 `SYMBOLS` 列表中，将占位符开箱符号替换为全角空格
- 更新游戏特定的用户名检查，以使用重命名后的常量

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Sega player name validation by renaming the username character set constant and updating the allowed symbols list to include a fullwidth space

Enhancements:
- Rename SEGA_USERNAME_CAHRS constant to SEGA_USERNAME_CHARS to correct typo
- Replace placeholder open-box symbol with a fullwidth space in the SYMBOLS list
- Update game-specific username checks to use the renamed constant

</details>