### PR TITLE
feat: :sparkles: option APIs for chu3, mai2 & ongeki

### DIFF
--- a/src/main/java/icu/samnyan/aqua/net/games/GameApiController.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/GameApiController.kt
@@ -143,13 +143,9 @@ abstract class GameApiController<T : IUserData>(val name: String, userDataClass:
     }
 
     @API("user-option")
-    open suspend fun userOption(@RP token: String): Any {
-        400 - "Unsupported by this game"
-    }
+    open suspend fun userOption(@RP token: String): Any = 400 - "Unsupported by this game"
     @API("user-option-set")
-    open suspend fun userOptionSet(@RP token: String, @RP field: String, @RP value: Int): Any {
-        400 - "Unsupported by this game"
-    }
+    open suspend fun userOptionSet(@RP token: String, @RP field: String, @RP value: Int): Any = 400 - "Unsupported by this game"
 
     @API("user-music-from-list")
     suspend fun userMusicFromList(@RP username: Str, @RB musicList: List<Int>) = us.cardByName(username) { card ->

--- a/src/main/java/icu/samnyan/aqua/net/games/GameApiController.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/GameApiController.kt
@@ -143,7 +143,7 @@ abstract class GameApiController<T : IUserData>(val name: String, userDataClass:
     }
 
     @API("user-option")
-    open suspend fun userOption(@RP token: String): Any = 400 - "Unsupported by this game"
+    open suspend fun userOption(@RP token: String): Any? = 400 - "Unsupported by this game"
     @API("user-option-set")
     open suspend fun userOptionSet(@RP token: String, @RP field: String, @RP value: Int): Any = 400 - "Unsupported by this game"
 

--- a/src/main/java/icu/samnyan/aqua/net/games/GameApiController.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/GameApiController.kt
@@ -27,6 +27,7 @@ abstract class GameApiController<T : IUserData>(val name: String, userDataClass:
     abstract val playlogRepo: GenericPlaylogRepo<*>
     abstract val userMusicRepo: GenericUserMusicRepo<*>
     abstract val shownRanks: List<Pair<Int, String>>
+
     abstract val settableFields: Map<String, (T, String) -> Unit>
     open val gettableFields: Set<String> = setOf()
 
@@ -124,13 +125,11 @@ abstract class GameApiController<T : IUserData>(val name: String, userDataClass:
         (settableFields.keys.toSet() + gettableFields)
             .associateWith { k -> (vm[k] ?: error("Field $k not found")) }
     } }
-
     @API("user-detail")
     suspend fun userDetail(@RP username: String) = us.cardByName(username) { card ->
         val u = userDataRepo.findByCard(card) ?: (404 - "User not found")
         userDetailFields.toList().associate { (k, f) -> k to f.invoke(u) }
     }
-
     @API("user-detail-set")
     suspend fun userDetailSet(@RP token: String, @RP field: String, @RP value: String): Any {
         val prop = settableFields[field] ?: (400 - "Invalid field $field")
@@ -141,6 +140,15 @@ abstract class GameApiController<T : IUserData>(val name: String, userDataClass:
             async { userDataRepo.save(user) }
             SUCCESS
         }
+    }
+
+    @API("user-option")
+    open suspend fun userOption(@RP token: String): Any {
+        400 - "Unsupported by this game"
+    }
+    @API("user-option-set")
+    open suspend fun userOptionSet(@RP token: String, @RP field: String, @RP value: Int): Any {
+        400 - "Unsupported by this game"
     }
 
     @API("user-music-from-list")

--- a/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
@@ -101,8 +101,8 @@ class Chusan(
     }
 
     @API("user-option")
-    override suspend fun userOption(@RP token: String): Any = us.jwt.auth(token) { u ->
-        rp.userGameOption.findByUser_Card_ExtId(u.ghostCard.extId)
+    override suspend fun userOption(@RP token: String): Any? = us.jwt.auth(token) { u ->
+        rp.userGameOption.findByUser_Card_ExtId(u.ghostCard.extId).getOrNull(0)
     }
     @API("user-option-set")
     override suspend fun userOptionSet(@RP token: String, @RP field: String, @RP value: Int): Any = us.jwt.auth(token) { u ->

--- a/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
@@ -106,15 +106,15 @@ class Chusan(
     }
     @API("user-option-set")
     override suspend fun userOptionSet(@RP token: String, @RP field: String, @RP value: Int): Any = us.jwt.auth(token) { u ->
-        val gameOptions = rp.userGameOption.findSingleByUser_Card_ExtId(u.ghostCard.extId).get()
+        val gameOptions = rp.userGameOption.findSingleByUser_Card_ExtId(u.ghostCard.extId).getOrNull()
         val property = UserGameOption::class.memberProperties.filterIsInstance<KMutableProperty1<Any, Any?>>().find{ it.name == field }
 
-        if (property != null) {
+        if (property != null && gameOptions != null) {
             property.setter.call(gameOptions, value)
             rp.userGameOption.save(gameOptions)
+            200 - "Success"
         } else
-            400 - "Invalid option"
-        200 - "Success"
+            400 - "Invalid parameters"
     }
 
     // UserBox related APIs

--- a/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/chu3/Chusan.kt
@@ -6,7 +6,12 @@ import icu.samnyan.aqua.net.games.*
 import icu.samnyan.aqua.net.utils.*
 import icu.samnyan.aqua.sega.chusan.model.*
 import icu.samnyan.aqua.sega.chusan.model.userdata.Chu3UserData
+import icu.samnyan.aqua.sega.chusan.model.userdata.UserGameOption
 import org.springframework.web.bind.annotation.RestController
+import kotlin.jvm.optionals.getOrNull
+import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.memberProperties
 
 @RestController
 @API("api/v2/game/chu3")
@@ -33,6 +38,7 @@ class Chusan(
         "trophyIdSub2" to { u, v -> u.trophyIdSub2 = v.int },
         "mapIconId" to { u, v -> u.mapIconId = v.int },
         "voiceId" to { u, v -> u.voiceId = v.int },
+        "characterId" to { u, v -> u.characterId = v.int },
         "avatarWear" to { u, v -> u.avatarWear = v.int },
         "avatarHead" to { u, v -> u.avatarHead = v.int },
         "avatarFace" to { u, v -> u.avatarFace = v.int },
@@ -44,7 +50,7 @@ class Chusan(
         "lastRomVersion" to { u, v -> u.lastRomVersion = v },
         "lastDataVersion" to { u, v -> u.lastDataVersion = v },
     ) }
-    override val gettableFields: Set<String> = setOf("level", "playerRating", "characterId")
+    override val gettableFields: Set<String> = setOf("level", "playerRating")
 
     override suspend fun userSummary(@RP username: Str, @RP token: String?) = us.cardByName(username) { card ->
         // Summary values: total plays, player rating, server-wide ranking
@@ -92,6 +98,23 @@ class Chusan(
             "recent10" to recent10,
             "musicList" to userMusicList,
         )
+    }
+
+    @API("user-option")
+    override suspend fun userOption(@RP token: String): Any = us.jwt.auth(token) { u ->
+        rp.userGameOption.findByUser_Card_ExtId(u.ghostCard.extId)
+    }
+    @API("user-option-set")
+    override suspend fun userOptionSet(@RP token: String, @RP field: String, @RP value: Int): Any = us.jwt.auth(token) { u ->
+        val gameOptions = rp.userGameOption.findSingleByUser_Card_ExtId(u.ghostCard.extId).get()
+        val property = UserGameOption::class.memberProperties.filterIsInstance<KMutableProperty1<Any, Any?>>().find{ it.name == field }
+
+        if (property != null) {
+            property.setter.call(gameOptions, value)
+            rp.userGameOption.save(gameOptions)
+        } else
+            400 - "Invalid option"
+        200 - "Success"
     }
 
     // UserBox related APIs

--- a/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
@@ -11,6 +11,8 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.*
+import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.full.memberProperties
 
 @RestController
 @API("api/v2/game/mai2")
@@ -141,6 +143,23 @@ class Maimai2(
             repos.userLoginBonus.saveAll(loginBonus)
         }
         SUCCESS
+    }
+
+    @API("user-option")
+    override suspend fun userOption(@RP token: String) = us.jwt.auth(token) { u ->
+        repos.userOption.findByUser_Card_ExtId(u.ghostCard.extId)
+    }
+    @API("user-option-set")
+    override suspend fun userOptionSet(@RP token: String, @RP field: String, @RP value: Int): Any = us.jwt.auth(token) { u ->
+        val gameOptions = repos.userOption.findSingleByUser_Card_ExtId(u.ghostCard.extId).get()
+        val property = Mai2UserOption::class.memberProperties.filterIsInstance<KMutableProperty1<Any, Any?>>().find{ it.name == field }
+
+        if (property != null) {
+            property.setter.call(gameOptions, value)
+            repos.userOption.save(gameOptions)
+        } else
+            400 - "Invalid option"
+        200 - "Success"
     }
 
     @API("owned-items")

--- a/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.*
+import kotlin.jvm.optionals.getOrNull
 import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.full.memberProperties
 
@@ -151,15 +152,16 @@ class Maimai2(
     }
     @API("user-option-set")
     override suspend fun userOptionSet(@RP token: String, @RP field: String, @RP value: Int): Any = us.jwt.auth(token) { u ->
-        val gameOptions = repos.userOption.findSingleByUser_Card_ExtId(u.ghostCard.extId).get()
+        val gameOptions = repos.userOption.findSingleByUser_Card_ExtId(u.ghostCard.extId).getOrNull()
         val property = Mai2UserOption::class.memberProperties.filterIsInstance<KMutableProperty1<Any, Any?>>().find{ it.name == field }
 
-        if (property != null) {
+        if (property != null && gameOptions != null) {
             property.setter.call(gameOptions, value)
             repos.userOption.save(gameOptions)
+            200 - "Success"
         } else
-            400 - "Invalid option"
-        200 - "Success"
+            400 - "Invalid parameters"
+
     }
 
     @API("owned-items")

--- a/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/mai2/Maimai2.kt
@@ -148,7 +148,7 @@ class Maimai2(
 
     @API("user-option")
     override suspend fun userOption(@RP token: String) = us.jwt.auth(token) { u ->
-        repos.userOption.findByUser_Card_ExtId(u.ghostCard.extId)
+        repos.userOption.findByUser_Card_ExtId(u.ghostCard.extId).getOrNull(0)
     }
     @API("user-option-set")
     override suspend fun userOptionSet(@RP token: String, @RP field: String, @RP value: Int): Any = us.jwt.auth(token) { u ->

--- a/src/main/java/icu/samnyan/aqua/net/games/ongeki/Ongeki.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/ongeki/Ongeki.kt
@@ -1,15 +1,22 @@
 package icu.samnyan.aqua.net.games.ongeki
 
 import ext.API
+import ext.RP
+import ext.minus
 import icu.samnyan.aqua.net.db.AquaUserServices
 import icu.samnyan.aqua.net.games.*
 import icu.samnyan.aqua.net.utils.*
 import icu.samnyan.aqua.sega.ongeki.OgkUserDataRepo
 import icu.samnyan.aqua.sega.ongeki.OgkUserGeneralDataRepo
 import icu.samnyan.aqua.sega.ongeki.OgkUserMusicDetailRepo
+import icu.samnyan.aqua.sega.ongeki.OgkUserOptionRepo
 import icu.samnyan.aqua.sega.ongeki.OgkUserPlaylogRepo
 import icu.samnyan.aqua.sega.ongeki.model.UserData
+import icu.samnyan.aqua.sega.ongeki.model.UserOption
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.full.memberProperties
 
 @RestController
 @API("api/v2/game/ongeki")
@@ -18,7 +25,8 @@ class Ongeki(
     override val playlogRepo: OgkUserPlaylogRepo,
     override val userDataRepo: OgkUserDataRepo,
     override val userMusicRepo: OgkUserMusicDetailRepo,
-    val userGeneralDataRepository: OgkUserGeneralDataRepo
+    val userGeneralDataRepository: OgkUserGeneralDataRepo,
+    val userOptionRepo: OgkUserOptionRepo
 ): GameApiController<UserData>("ongeki", UserData::class) {
     override suspend fun trend(username: String) = us.cardByName(username) { card ->
         findTrend(playlogRepo.findByUser_Card_ExtId(card.extId)
@@ -44,5 +52,22 @@ class Ongeki(
         )
 
         genericUserSummary(card, ratingComposition)
+    }
+
+    @API("user-option")
+    override suspend fun userOption(@RP token: String) = us.jwt.auth(token) { u ->
+        userOptionRepo.findByUser_Card_ExtId(u.ghostCard.extId)
+    }
+    @API("user-option-set")
+    override suspend fun userOptionSet(@RP token: String, @RP field: String, @RP value: Int): Any = us.jwt.auth(token) { u ->
+        val gameOptions = userOptionRepo.findSingleByUser_Card_ExtId(u.ghostCard.extId).get()
+        val property = UserOption::class.memberProperties.filterIsInstance<KMutableProperty1<Any, Any?>>().find{ it.name == field }
+
+        if (property != null) {
+            property.setter.call(gameOptions, value)
+            userOptionRepo.save(gameOptions)
+        } else
+            400 - "Invalid option"
+        200 - "Success"
     }
 }

--- a/src/main/java/icu/samnyan/aqua/net/games/ongeki/Ongeki.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/ongeki/Ongeki.kt
@@ -57,7 +57,7 @@ class Ongeki(
 
     @API("user-option")
     override suspend fun userOption(@RP token: String) = us.jwt.auth(token) { u ->
-        userOptionRepo.findByUser_Card_ExtId(u.ghostCard.extId)
+        userOptionRepo.findByUser_Card_ExtId(u.ghostCard.extId).getOrNull(0)
     }
     @API("user-option-set")
     override suspend fun userOptionSet(@RP token: String, @RP field: String, @RP value: Int): Any = us.jwt.auth(token) { u ->

--- a/src/main/java/icu/samnyan/aqua/net/games/ongeki/Ongeki.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/ongeki/Ongeki.kt
@@ -15,6 +15,7 @@ import icu.samnyan.aqua.sega.ongeki.model.UserData
 import icu.samnyan.aqua.sega.ongeki.model.UserOption
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import kotlin.jvm.optionals.getOrNull
 import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.full.memberProperties
 
@@ -60,14 +61,14 @@ class Ongeki(
     }
     @API("user-option-set")
     override suspend fun userOptionSet(@RP token: String, @RP field: String, @RP value: Int): Any = us.jwt.auth(token) { u ->
-        val gameOptions = userOptionRepo.findSingleByUser_Card_ExtId(u.ghostCard.extId).get()
+        val gameOptions = userOptionRepo.findSingleByUser_Card_ExtId(u.ghostCard.extId).getOrNull()
         val property = UserOption::class.memberProperties.filterIsInstance<KMutableProperty1<Any, Any?>>().find{ it.name == field }
 
-        if (property != null) {
+        if (property != null && gameOptions != null) {
             property.setter.call(gameOptions, value)
             userOptionRepo.save(gameOptions)
+            200 - "Success"
         } else
-            400 - "Invalid option"
-        200 - "Success"
+            400 - "Invalid parameters"
     }
 }


### PR DESCRIPTION
Chusan, Mai and Ongeki all use the same `Map<String, Int>` structure for their game option parameters, so they share implementations more or less.

Because the parameters between games are so drastically different, I decided to pick the reflection route (instead of creating a common class) and update the parameters on their own. Unfortunately this means I had to duplicate code. If there's a better way to implement this, please let me know.

**Note: This does not add AquaNet interfaces as it's not a planned feature for AquaNet. I want to get this out in production now so we can test on AquaNet2.**

## Summary by Sourcery

基于共享的选项结构和通用的游戏控制器扩展，为 Chu3、Mai2 和 Ongeki 新增每个游戏的用户选项 API。

New Features:
- 为 Chusan 玩家提供使用基于 JWT 认证令牌的用户选项获取和更新接口。
- 为 Maimai2 玩家提供使用基于 JWT 认证令牌的用户选项获取和更新接口。
- 为 Ongeki 玩家提供使用基于 JWT 认证令牌的用户选项获取和更新接口。

Enhancements:
- 扩展基础游戏 API 控制器，加入可被重写的用户选项处理程序和默认的“不支持”响应，以在各游戏之间统一和标准化选项 API。
- 调整 Chusan 用户详情配置，包括新增一个与角色相关的字段映射，以适配新的选项系统。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-game user option APIs for Chu3, Mai2, and Ongeki based on shared option structures and a common game controller extension.

New Features:
- Expose user option retrieval and update endpoints for Chusan players using JWT-authenticated tokens.
- Expose user option retrieval and update endpoints for Maimai2 players using JWT-authenticated tokens.
- Expose user option retrieval and update endpoints for Ongeki players using JWT-authenticated tokens.

Enhancements:
- Extend the base game API controller with overridable user option handlers and default unsupported responses to standardize option APIs across games.
- Adjust Chusan user detail configuration, including an additional character-related field mapping, to align with the new option system.

</details>