### PR TITLE
Fix: KALEIDXSCOPE crashing on final phase

### DIFF
--- a/src/main/java/icu/samnyan/aqua/sega/maimai2/Maimai2Apis.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/maimai2/Maimai2Apis.kt
@@ -224,12 +224,16 @@ fun Maimai2ServletController.initApis() {
     // Kaleidoscope, added on 1.50
     // [{gateId, phaseId}]
     "GetGameKaleidxScope" { mapOf("gameKaleidxScopeList" to ls(
-        mapOf("gateId" to 1, "phaseId" to findPhase(LocalDate.of(2025, 1, 18))),
-        mapOf("gateId" to 2, "phaseId" to 2),
-        mapOf("gateId" to 3, "phaseId" to 2),
-        mapOf("gateId" to 4, "phaseId" to findPhase(LocalDate.of(2025, 2, 25))),
-        mapOf("gateId" to 5, "phaseId" to 2),
-        mapOf("gateId" to 6, "phaseId" to 2),
+        mapOf("gateId" to 1, "phaseId" to 6),
+        mapOf("gateId" to 2, "phaseId" to 6),
+        mapOf("gateId" to 3, "phaseId" to 6),
+        mapOf("gateId" to 4, "phaseId" to 6),
+        mapOf("gateId" to 5, "phaseId" to 6),
+        mapOf("gateId" to 6, "phaseId" to 6),
+        mapOf("gateId" to 7, "phaseId" to 6),
+        mapOf("gateId" to 8, "phaseId" to 6),
+        mapOf("gateId" to 9, "phaseId" to 6),
+        mapOf("gateId" to 10, "phaseId" to 13),
     )) }
     // Request: {userId}
     // Response: {userId, userKaleidxScopeList}


### PR DESCRIPTION
Add Gates 7-10 to prevent crashing when entered

Set Gates 1-9 to LIFE999 BASIC
Set Gate 10 to LIFE999/999 BASIC

## Summary by Sourcery

更新 KALEIDXSCOPE 闸门配置，以防止崩溃，并使所有闸门与正确的最终阶段设置保持一致。

Bug 修复：
- 通过确保所有闸门都有有效的阶段映射，防止在进入编号较高的闸门时 KALEIDXSCOPE 崩溃。

增强内容：
- 将 1–9 号闸门统一为使用 LIFE999 BASIC 阶段，并将 10 号闸门配置为使用 LIFE999/999 BASIC 阶段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update KALEIDXSCOPE gate configuration to prevent crashes and align all gates with the correct final-phase settings.

Bug Fixes:
- Prevent KALEIDXSCOPE from crashing when entering higher-numbered gates by ensuring all gates have valid phase mappings.

Enhancements:
- Standardize gates 1–9 to use the LIFE999 BASIC phase and configure gate 10 to use the LIFE999/999 BASIC phase.

</details>