### PR TITLE
feat: batch manual export for mai2

### DIFF
--- a/AquaNet/src/components/settings/Mai2Settings.svelte
+++ b/AquaNet/src/components/settings/Mai2Settings.svelte
@@ -134,6 +134,7 @@
     if (data && "userPlaylogList" in data) {
       for (let score of data.userPlaylogList) {
         const musicItem = musicData[score.musicId as string];
+        if (!musicItem) continue;
         const songTitle = musicItem.name;
         const version = parseInt(musicItem["ver"]);
         let difficulty = null;

--- a/AquaNet/src/components/settings/Mai2Settings.svelte
+++ b/AquaNet/src/components/settings/Mai2Settings.svelte
@@ -126,6 +126,9 @@
     }
     if (data && "userPlaylogList" in data) {
       for (let score of data.userPlaylogList) {
+        if(score.musicId > 100000){
+          continue; // UTAGE charts are not supported
+        }
         const musicItem = musicData[score.musicId as string];
         if (!musicItem) continue;
         let difficulty = null;

--- a/AquaNet/src/components/settings/Mai2Settings.svelte
+++ b/AquaNet/src/components/settings/Mai2Settings.svelte
@@ -135,11 +135,9 @@
       for (let score of data.userPlaylogList) {
         const musicItem = musicData[score.musicId as string];
         if (!musicItem) continue;
-        const songTitle = musicItem.name;
-        const version = parseInt(musicItem["ver"]);
         let difficulty = null;
 
-        if (musicid >= 10000) { // DX difficulty
+        if (score.musicid >= 10000) { // DX difficulty
           difficulty = DX_DIFFICULTY_MAP[score.level];
         } else {
           difficulty = ST_DIFFICULTY_MAP[score.level];
@@ -185,8 +183,8 @@
         output.scores.push({
           "percent": percent,
           "lamp": lamp,
-          "matchType": "songTitle",
-          "identifier": songTitle,
+          "matchType": "inGameID",
+          "identifier": score.musicId.toString(),
           "difficulty": difficulty,
           "timeAchieved": new Date(score.userPlayDate).getTime(),
           "judgements": judgements,

--- a/AquaNet/src/components/settings/Mai2Settings.svelte
+++ b/AquaNet/src/components/settings/Mai2Settings.svelte
@@ -137,7 +137,7 @@
         if (!musicItem) continue;
         let difficulty = null;
 
-        if (score.musicid >= 10000) { // DX difficulty
+        if (score.musicId >= 10000) { // DX difficulty
           difficulty = DX_DIFFICULTY_MAP[score.level];
         } else {
           difficulty = ST_DIFFICULTY_MAP[score.level];

--- a/AquaNet/src/components/settings/Mai2Settings.svelte
+++ b/AquaNet/src/components/settings/Mai2Settings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { slide, fade } from "svelte/transition";
-  import { FADE_IN, FADE_OUT } from "../../libs/config";
+  import { FADE_IN, FADE_OUT, DATA_HOST } from "../../libs/config";
   import { t } from "../../libs/i18n.js";
   import Icon from "@iconify/svelte";
   import StatusOverlays from "../StatusOverlays.svelte";
@@ -34,6 +34,174 @@
         }).catch(e => error = e.message).finally(() => submitting = "")
         break
     }
+  }
+  async function exportBatchManual() {
+    submitting = "batchExport"
+    const ST_DIFFICULTY_MAP: Record<number, string> = {
+      0: "Basic",
+      1: "Advanced",
+      2: "Expert",
+      3: "Master",
+      4: "Re:Master"
+    }
+
+    const DX_DIFFICULTY_MAP: Record<number, string> = {
+      0: "DX Basic",
+      1: "DX Advanced",
+      2: "DX Expert",
+      3: "DX Master",
+      4: "DX Re:Master"
+    }
+    const DAN_MAP: Record<number, string> = {
+      1: "DAN_1",
+      2: "DAN_2",
+      3: "DAN_3",
+      4: "DAN_4",
+      5: "DAN_5",
+      6: "DAN_6",
+      7: "DAN_7",
+      8: "DAN_8",
+      9: "DAN_9",
+      10: "DAN_10",
+      11: "SHINDAN_1",
+      12: "SHINDAN_2",
+      13: "SHINDAN_3",
+      14: "SHINDAN_4",
+      15: "SHINDAN_5",
+      16: "SHINDAN_6",
+      17: "SHINDAN_7",
+      18: "SHINDAN_8",
+      19: "SHINDAN_9",
+      20: "SHINDAN_10",
+      21: "SHINKAIDEN",
+      22: "URAKAIDEN"
+    }
+
+    const CLASS_MAP: Record<number, string> = {
+      0: "B5",
+      1: "B4",
+      2: "B3",
+      3: "B2",
+      4: "B1",
+      5: "A5",
+      6: "A4",
+      7: "A3",
+      8: "A2",
+      9: "A1",
+      10: "S5",
+      11: "S4",
+      12: "S3",
+      13: "S2",
+      14: "S1",
+      15: "SS5",
+      16: "SS4",
+      17: "SS3",
+      18: "SS2",
+      19: "SS1",
+      20: "SSS5",
+      21: "SSS4",
+      22: "SSS3",
+      23: "SSS2",
+      24: "SSS1",
+      25: "LEGEND"
+    }
+
+    let data: any
+    let musicData: any
+    let output: any = {
+      "meta": {
+        "game": "maimaidx",
+        "playtype": "Single",
+        "service": "AquaDX-Manual"
+      },
+      "scores": [],
+      "classes": {}
+    }
+    try {
+      musicData = await fetch(`${DATA_HOST}/d/mai2/00/all-music.json`).then(res => res.json())
+    } catch (e) {
+      error = e.message;
+      submitting = ""
+      return;
+    }
+    try {
+      data = await GAME.export('mai2');
+    } catch (e) {
+      error = e.message;
+      submitting = ""
+      return;
+    }
+    if (data && "userPlaylogList" in data) {
+      for (let score of data.userPlaylogList) {
+        const musicItem = musicData[score.musicId as string];
+        const songTitle = musicItem.name;
+        const version = parseInt(musicItem["ver"]);
+        let difficulty = null;
+
+        if (version >= 20000) { // DX difficulty
+          difficulty = DX_DIFFICULTY_MAP[score.level];
+        } else {
+          difficulty = ST_DIFFICULTY_MAP[score.level];
+        }
+
+        const percent = score.achievement/10000;
+
+        const pcrit = score.tapCriticalPerfect + score.holdCriticalPerfect + score.slideCriticalPerfect + score.touchCriticalPerfect + score.breakCriticalPerfect;
+        const perfect = score.tapPerfect + score.holdPerfect + score.slidePerfect + score.touchPerfect + score.breakPerfect;
+        const great = score.tapGreat + score.holdGreat + score.slideGreat + score.touchGreat + score.breakGreat;
+        const good = score.tapGood + score.holdGood + score.slideGood + score.touchGood + score.breakGood;
+        const miss = score.tapMiss + score.holdMiss + score.slideMiss + score.touchMiss + score.breakMiss;
+        const judgements  = {
+          "pcrit": pcrit,
+          "perfect": perfect,
+          "great": great,
+          "good": good,
+          "miss": miss
+        }
+        let lamp = null;
+        if (score.isAllPerfect) {
+          lamp = "ALL PERFECT";
+          if (score.percent == 101.0) {
+            lamp = "ALL PERFECT+";
+          }
+        } else if (score.isFullCombo) {
+          lamp = "FULL COMBO";
+          if (good == 0 && great == 0) {
+            lamp = "FULL COMBO+";
+          }
+        } else if (score.isClear) {
+          lamp = "CLEAR";
+        } else {
+          lamp = "FAILED";
+        }
+
+        const optional = {
+          "fast": score.fastCount,
+          "slow": score.lateCount,
+          "maxCombo": score.maxCombo
+        }
+
+        output.scores.push({
+          "percent": percent,
+          "lamp": lamp,
+          "matchType": "songTitle",
+          "identifier": songTitle,
+          "difficulty": difficulty,
+          "timeAchieved": new Date(score.userPlayDate).getTime(),
+          "judgements": judgements,
+          "optional": optional
+        })
+      }
+    }
+
+    if(data.userData.courseRank in DAN_MAP){
+      output.classes["dan"] = DAN_MAP[data.userData.courseRank]
+    }
+    if(data.userData.classRank in CLASS_MAP){
+      output.classes["matchingClass"] = CLASS_MAP[data.userData.classRank]
+    }
+    download(JSON.stringify(output), `AquaDX_maimai2_BatchManualExport_${values[0]}.json`)
+    submitting = ""
   }
 
   function exportData() {
@@ -69,6 +237,10 @@
   <button class="exportButton" on:click={exportData}>
     <Icon icon="bxs:file-export"/>
     {t('settings.export')}
+  </button>
+  <button class="exportBatchManualButton" on:click={exportBatchManual}>
+    <Icon icon="bxs:file-export"/>
+    {t('settings.batchManualExport')}
   </button>
 </div>
 

--- a/AquaNet/src/components/settings/Mai2Settings.svelte
+++ b/AquaNet/src/components/settings/Mai2Settings.svelte
@@ -139,7 +139,7 @@
         const version = parseInt(musicItem["ver"]);
         let difficulty = null;
 
-        if (version >= 20000) { // DX difficulty
+        if (musicid >= 10000) { // DX difficulty
           difficulty = DX_DIFFICULTY_MAP[score.level];
         } else {
           difficulty = ST_DIFFICULTY_MAP[score.level];

--- a/AquaNet/src/components/settings/Mai2Settings.svelte
+++ b/AquaNet/src/components/settings/Mai2Settings.svelte
@@ -37,7 +37,7 @@
   }
   async function exportBatchManual() {
     submitting = "batchExport"
-    const ST_DIFFICULTY_MAP: Record<number, string> = {
+    const DIFFICULTY_MAP: Record<number, string> = {
       0: "Basic",
       1: "Advanced",
       2: "Expert",
@@ -45,13 +45,6 @@
       4: "Re:Master"
     }
 
-    const DX_DIFFICULTY_MAP: Record<number, string> = {
-      0: "DX Basic",
-      1: "DX Advanced",
-      2: "DX Expert",
-      3: "DX Master",
-      4: "DX Re:Master"
-    }
     const DAN_MAP: Record<number, string> = {
       1: "DAN_1",
       2: "DAN_2",
@@ -137,11 +130,11 @@
         if (!musicItem) continue;
         let difficulty = null;
 
-        if (score.musicId >= 10000) { // DX difficulty
-          difficulty = DX_DIFFICULTY_MAP[score.level];
-        } else {
-          difficulty = ST_DIFFICULTY_MAP[score.level];
-        }
+        if (!(score.level in DIFFICULTY_MAP))
+          continue;
+
+        const isDX = score.musicId >= 10000;
+        difficulty = isDX ? `DX ${DIFFICULTY_MAP[score.level]}` : DIFFICULTY_MAP[score.level];
 
         const percent = score.achievement/10000;
 


### PR DESCRIPTION
Tachi batch manual export for mai2. Similar to chuni logic but requires the all-music json since for Tachi can only accept songName as the match type for mai2.

Not sure if there is a better heuristic to use for figuring out whether a chart is DX difficulty or standard, but from my testing it works correctly (only matters for a few edge cases that have both standard and DX charts since I think Tachi will auto correct).

## Summary by Sourcery

为 maimai DX（mai2）设置添加批量手动导出支持，生成与 Tachi 兼容的游玩记录与段位数据 JSON 导出文件。

New Features:
- 为 mai2 引入批量手动导出流程，将用户的游玩记录聚合为单个 JSON 文件供下载。
- 在导出的批量 JSON 数据中包含 maimai DX 的段位与等级（class rank）信息。
- 在 Mai2 设置界面中提供一个新的设置按钮，用于触发批量手动导出。

Enhancements:
- 在准备批量手动导出时，从共享数据主机加载 mai2 的全曲目元数据，以支持谱面映射。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add batch manual export support for maimai DX (mai2) settings, producing a Tachi-compatible JSON export of playlogs and classes.

New Features:
- Introduce a batch manual export flow for mai2 that aggregates user playlogs into a single JSON file for download.
- Include maimai DX dan and class rank data in the exported batch JSON payload.
- Expose a new settings button in the Mai2 settings UI to trigger the batch manual export.

Enhancements:
- Load mai2 all-music metadata from the shared data host when preparing batch manual exports to support chart mapping.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 maimai DX（mai2）设置添加批量手动导出支持，生成与 Tachi 兼容的游玩记录与段位数据 JSON 导出文件。

New Features:
- 为 mai2 引入批量手动导出流程，将用户的游玩记录聚合为单个 JSON 文件供下载。
- 在导出的批量 JSON 数据中包含 maimai DX 的段位与等级（class rank）信息。
- 在 Mai2 设置界面中提供一个新的设置按钮，用于触发批量手动导出。

Enhancements:
- 在准备批量手动导出时，从共享数据主机加载 mai2 的全曲目元数据，以支持谱面映射。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add batch manual export support for maimai DX (mai2) settings, producing a Tachi-compatible JSON export of playlogs and classes.

New Features:
- Introduce a batch manual export flow for mai2 that aggregates user playlogs into a single JSON file for download.
- Include maimai DX dan and class rank data in the exported batch JSON payload.
- Expose a new settings button in the Mai2 settings UI to trigger the batch manual export.

Enhancements:
- Load mai2 all-music metadata from the shared data host when preparing batch manual exports to support chart mapping.

</details>

</details>