### PR TITLE
feat: maimai DX CiRCLE PLUS

### DIFF
--- a/src/main/java/icu/samnyan/aqua/sega/maimai2/Maimai2Apis.kt
+++ b/src/main/java/icu/samnyan/aqua/sega/maimai2/Maimai2Apis.kt
@@ -211,7 +211,8 @@ fun Maimai2ServletController.initApis() {
     "GetUserCardPrintError" static { mapOf("length" to 0, "userPrintDetailList" to empty) }
     "GetUserFriendCheck" static { mapOf("returnCode" to 0) }
     "UserFriendRegist" static { mapOf("returnCode1" to 0, "returnCode2" to 0) }
-    "GetGameNgMusicId" static { mapOf("length" to 0, "musicIdList" to empty) }
+    "GetGameNgMusicId" static { mapOf("length" to 0, "musicIdList" to empty, "ngMusicDataList" to empty) }
+    "GetGameNationalData" static { mapOf("nextIndex" to 0, "nationalDataList" to empty) }
     "GetGameTournamentInfo" static { mapOf("length" to 0, "gameTournamentInfoList" to empty) }
 
     // <phaseId: start offset days>
@@ -375,6 +376,13 @@ fun Maimai2ServletController.initApis() {
         "circleClass" to 0,
         "lastLoginDate" to "",
         "circlePointRankingList" to empty
+    ) }
+
+    "GetUserCircleChallenge" { mapOf(
+        "userId" to uid,
+        "userCircleChallenge" to null,
+        "circleCircleChallenge" to null,
+        "achievement" to 0
     ) }
 
     "GetUserCirclePointData" { mapOf(


### PR DESCRIPTION
## 由 Sourcery 提供的总结

扩展 maimai DX API 存根，以支持额外的游戏和圈子挑战数据响应。

新功能：
- 新增对 GetGameNationalData API 的支持，目前返回空的全国数据响应。
- 在 GetGameNgMusicId API 的响应中加入 `ngMusicDataList` 字段。
- 新增 GetUserCircleChallenge API 端点，返回默认的圈子挑战数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend maimai DX API stubs to support additional game and circle challenge data responses.

New Features:
- Add support for GetGameNationalData API with empty national data response.
- Include ngMusicDataList field in GetGameNgMusicId API responses.
- Add GetUserCircleChallenge API endpoint returning default circle challenge data.

</details>