### PR TITLE
ranking: do not use status overlays

### DIFF
--- a/AquaNet/src/pages/Ranking.svelte
+++ b/AquaNet/src/pages/Ranking.svelte
@@ -3,7 +3,6 @@
   import { title } from "../libs/ui";
   import { GAME } from "../libs/sdk";
   import type { GenericRanking } from "../libs/generalTypes";
-  import StatusOverlays from "../components/StatusOverlays.svelte";
   import type { GameName } from "../libs/scoring";
   import { GAME_TITLE } from "../libs/i18n";
   import { t } from "../libs/i18n";
@@ -86,9 +85,9 @@
     <Tooltip triggeredBy=".name" loading={hoverLoading}>
       <UserCard username={hoveringUser} {game} setLoading={l => hoverLoading = l} />
     </Tooltip>
+  {:else}
+    <p>{error}</p>
   {/if}
-
-  <StatusOverlays error={error} loading={!loadedPages} />
 </main>
 
 <style lang="sass">

--- a/src/main/java/icu/samnyan/aqua/net/games/GameApiController.kt
+++ b/src/main/java/icu/samnyan/aqua/net/games/GameApiController.kt
@@ -57,7 +57,7 @@ abstract class GameApiController<T : IUserData>(val name: String, userDataClass:
         val time = millis()
 
         // Check cache validity
-        if (rankingCache.isEmpty()) (500 - "Ranking is computing... please wait")
+        if (rankingCache.isEmpty()) (500 - "Rank is empty or is currently computing. Please come back later.")
 
         val reqUser = token?.let { us.jwt.auth(it) }?.let { u ->
             // Optimization: If the user is not banned, we don't need to process user information


### PR DESCRIPTION
some server might be only used for one specific game. the current AquaNet launch popup if one game has empty ranking.

also improved ranking empty server message.